### PR TITLE
feat(skills): add --unattended mode to forge-ship

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -86,7 +86,7 @@ Conventions shared across skills. When modifying any, update every skill that re
 |------------|--------|---------------|
 | Conventional commits | `<type>(<scope>): <description>` — titles, branches, commits, PRs | create-issue, implement, address-pr-feedback |
 | Canonical guidance file | `AGENTS.md` canonical; `CLAUDE.md` compatibility symlink | setup-project, implement, reflect |
-| Validate approach | Present plan and get user confirmation before implementing | implement |
+| Validate approach | Present plan and get user confirmation before implementing (skipped in unattended mode) | implement, ship |
 | Pre-flight validation | Verify external deps, config placement, generated types before feature code | implement |
 | Test as you go | Run tests after each commit, not just at the end | implement |
 | Pattern audit | When changing a pattern, update ALL files using it | implement, reflect |
@@ -105,6 +105,7 @@ Conventions shared across skills. When modifying any, update every skill that re
 | Durable decisions | Identify architectural decisions that survive implementation changes; keep as plan header | implement |
 | Skill composition | Composite skills reference other skills by path; orchestrators stay lean | ship |
 | Tool-layer integration | Reference external tools (e.g., `subagent`) by name with inline fallback | ship |
+| Unattended mode | `--unattended` flag skips user interaction; plan approval auto-proceeds, triage uses severity (P0–P1 fix, P2–P3 defer) | ship, implement |
 | Workflow order | setup → [brainstorm →] create → implement → reflect → address; ship composes implement + reflect | All skills |
 
 ## Instruction Budget

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -73,7 +73,7 @@ From the research (or your own codebase exploration for straightforward issues),
 
 Fold any optional additional context from `$ARGUMENTS` into the plan. If the issue includes Implementation Constraints (from `forge-create-issue`), follow those guardrails.
 
-Present the plan via AskUserQuestion. Get user confirmation before coding.
+Present the plan via AskUserQuestion. Get user confirmation before coding. **When called with unattended mode** (e.g., from `forge-ship --unattended`): skip AskUserQuestion and proceed with the plan.
 
 ### Step 3: Create Feature Branch
 

--- a/skills/forge-ship/SKILL.md
+++ b/skills/forge-ship/SKILL.md
@@ -21,11 +21,21 @@ Interpret `$ARGUMENTS` the same way as [forge-implement](../forge-implement/SKIL
 - `<free-text>` — inline description of what to build
 - Any of the above followed by `-- <additional context>`
 
+### Unattended Mode
+
+When `$ARGUMENTS` contains `--unattended`, the skill runs without user interaction:
+- Plan approval is skipped — the agent proceeds with the plan it creates
+- Review findings are auto-triaged using severity (see Step 4)
+
+Strip `--unattended` from the arguments before passing them to forge-implement.
+
 ## Process
 
 ### Step 1: Implement
 
 Read [forge-implement](../forge-implement/SKILL.md) and execute its Steps 1 through 8 (Understand → Plan → Branch → Implement → Pattern Audit → Docs → Quality Gates → Push & Create PR).
+
+**In unattended mode:** skip plan approval in forge-implement Step 2 — proceed with the plan without calling AskUserQuestion.
 
 Do not produce the implementation summary yet — the review will inform the final report.
 
@@ -64,13 +74,22 @@ Wait for the review results before proceeding.
 
 ### Step 4: Triage Findings
 
-Aggregate and deduplicate review findings. Present each to the user with a recommendation:
+Aggregate and deduplicate review findings.
+
+**In attended mode (default):** present each finding to the user with a recommendation:
 
 - **Fix now** — small, low-effort changes that fit in this PR → apply fix, commit
-- **Defer** — larger changes that expand PR scope → create a GitHub issue:
-  ```bash
-  gh issue create --title "<title>" --body "<context and proposed solution>"
-  ```
+- **Defer** — larger changes that expand PR scope → create a GitHub issue
+
+**In unattended mode:** auto-triage using severity from the [review rubric](../forge-reflect/references/review-rubric.md):
+
+- **P0–P1** → fix now, commit
+- **P2–P3** → defer, create a GitHub issue
+
+For both modes, deferred items become GitHub issues:
+```bash
+gh issue create --title "<title>" --body "<context and proposed solution>"
+```
 
 ### Step 5: Summary
 
@@ -101,11 +120,12 @@ Report implementation and review results together.
 
 ## Guidelines
 
-- **Implementation runs inline** — user interaction for plan approval is preserved
+- **Implementation runs inline** — user interaction for plan approval is preserved (unless `--unattended`)
 - **Review runs in fresh context** — sub-agent has no memory of implementation decisions
 - **Don't skip the review** — even if implementation felt clean, review catches blind spots
-- **Triage with the user** — don't auto-fix findings without asking
+- **Triage with the user** — don't auto-fix findings without asking (unless `--unattended`, which uses severity-based auto-triage)
 - **Graceful degradation** — the `subagent` tool is provided by external extensions; the skill works without it via inline fallback, but fresh-context review requires sub-agent support
+- **Unattended = severity-gated** — P0–P1 findings are always fixed; P2–P3 are always deferred. The review itself is never skipped.
 
 ## Related Skills
 
@@ -120,4 +140,6 @@ Report implementation and review results together.
 /forge-ship https://github.com/owner/repo/issues/42
 /forge-ship docs/roadmap.md
 /forge-ship add a dark mode toggle to the settings page
+/forge-ship --unattended 42
+/forge-ship --unattended 42 -- keep the diff minimal
 ```


### PR DESCRIPTION
## Summary
- Add `--unattended` flag to `forge-ship` that skips plan approval and auto-triages review findings by severity (P0–P1 fix now, P2–P3 defer)
- Update `forge-implement` to support skipping plan approval when called in unattended mode
- Add cross-skill consistency entry in `docs/coding-guidelines.md`

## Test plan
- [ ] Run `/forge-ship --unattended <issue>` end to end and verify no user prompts appear
- [ ] Verify attended mode (`/forge-ship <issue>`) still pauses for plan approval and triage
- [ ] Confirm P0–P1 findings are auto-fixed and P2–P3 are deferred as GitHub issues
- [ ] Verify `/forge-implement <issue>` standalone still asks for plan approval