### PR TITLE
refactor(skills): namespace roles, dedupe checklists, add CONTEXT.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ gh pr list                          # list open pull requests
 
 | Document | Purpose |
 |----------|---------|
+| [Context](CONTEXT.md) | Shared vocabulary used across forge skills |
 | [Architecture](docs/architecture.md) | Skill workflow, file format, role format, design decisions |
 | [Development](docs/development.md) | How to create and modify skills |
 | [Coding Guidelines](docs/coding-guidelines.md) | Skill authoring conventions and style rules |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# Forge Context
+
+Forge's shared vocabulary. This file defines language used across multiple skills. Terms used in only one skill stay local to that skill.
+
+## Language
+
+**Issue tracker** — currently GitHub Issues via `gh` CLI; Issue IDs are `#<number>`. Forge skills today assume GitHub; abstracting across providers (Linear, markdown folder) is on the roadmap, not yet reality.
+
+**Issue** — one tracked unit of work in the Issue tracker. Carries title, body, priority, labels, and an AFK/HITL mode.
+
+**Plan** — a structured proposal for implementing an Issue: durable decisions, vertical phases, verification steps. Lives either inline in conversation or as a markdown file referenced by skills.
+
+**Vertical slice** — an end-to-end implementation crossing all layers (UI → server → DB) for one narrow scenario, testable in isolation. Preferred over horizontal layer-by-layer slicing.
+
+**AFK / HITL** — Issue execution mode. **AFK** (away-from-keyboard): the Issue is fully specified for autonomous agent execution. **HITL** (human-in-the-loop): the Issue requires human judgment during implementation. Set when the Issue is created.
+
+**Reflection** — self-review of pending changes across four parallel dimensions (Correctness & Patterns, Security, Code Reuse & Quality, Efficiency & Tests & Docs) before peer review. Produces Findings.
+
+**Finding** — one issue surfaced by reflection or peer review, severity-tagged P0–P3. P3 findings are not flagged.
+
+**Deferred item** — a Finding not addressed in the current PR; becomes a new Issue.
+
+**Composite skill** — a skill that orchestrates other skills rather than doing work itself. Currently only `forge-ship` (composes `forge-implement` + `forge-reflect`).
+
+**Inline fallback** — the pattern where a `(delegate)` step provides both a sub-agent delegation path and an in-context alternative for runtimes without sub-agent support. Lets forge skills run anywhere.
+
+**Self-containment** — when multiple skills need the same role or reference, the file is duplicated rather than shared via cross-skill path. Skills install independently of each other; cross-skill paths break portability.
+
+**Pattern audit** — when a pattern changes in a diff, grep for ALL files using the old pattern and update them. Surfaced both during implementation and during reflection.
+
+**Quality gates** — lint, format, type check, tests. Run before commit, before PR push, and during reflection. A skill is responsible for both running them and reporting results.
+
+**Attended / unattended mode** — by default, skills pause for user confirmation at decision points (attended). Composite skills accept `--unattended` to skip prompts and use heuristics instead — e.g., `forge-ship --unattended` auto-triages findings by severity.
+
+**Trailing context** — `-- <additional context>` appended to a slash command, providing extra execution guidance without replacing the skill's primary input.
+
+**Three-tier context model** — the user repo's project context is structured as: `AGENTS.md` (hot, always loaded), `docs/*.md` (warm, on-demand by topic), specs (cold, deep references). Each tier must earn its token cost. Established by `forge-setup-project`.
+
+## Relationships
+
+- An **Issue** has one **AFK/HITL mode**, a priority, and labels.
+- A **Plan** implements one **Issue** through ordered **Vertical slices**.
+- A **Reflection** produces zero or more **Findings**; each Finding is either fixed in the current PR or becomes a **Deferred item** (a new Issue).
+- A **Composite skill** invokes other skills; its `--unattended` mode propagates through the composition.
+
+## Flagged ambiguities
+
+- "issue" was previously used to mean GitHub Issues specifically — resolved: **Issue** (capitalized) is the abstract concept, even though only the GitHub provider is implemented today.
+- "plan" was used loosely for both the structured proposal and a markdown file containing one — resolved: **Plan** is the proposal; "plan file" is a markdown artifact that contains a Plan.
+- "review" was used for both reflection (self-review) and peer review (external GitHub PR review) — resolved: **Reflection** is self-review by parallel sub-agents; **peer review** is external.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 </p>
 
 <p align="center">
+  <a href="CONTEXT.md">Context</a> &middot;
   <a href="docs/architecture.md">Architecture</a> &middot;
   <a href="docs/development.md">Development</a> &middot;
   <a href="docs/coding-guidelines.md">Guidelines</a> &middot;
@@ -71,6 +72,7 @@ Check your agent's docs for the correct skills directory path.
 
 | Document | Purpose |
 |----------|---------|
+| [Context](CONTEXT.md) | Shared vocabulary used across forge skills |
 | [Architecture](docs/architecture.md) | Skill workflow, file format, design decisions |
 | [Development](docs/development.md) | How to create and modify skills |
 | [Coding Guidelines](docs/coding-guidelines.md) | Skill authoring conventions and style rules |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,13 +14,13 @@ forge/
 │   ├── forge-create-issue/SKILL.md        # Step 1: Plan and create GitHub issues
 │   ├── forge-implement/
 │   │   ├── SKILL.md                       # Step 2: Implement from issue, plan, or description
-│   │   └── roles/scout.md                 # Blind codebase research persona
+│   │   └── roles/forge-scout.md           # Blind codebase research persona
 │   ├── forge-reflect/
 │   │   ├── SKILL.md                       # Step 3: Self-review changes (PR, branch, or uncommitted)
-│   │   ├── references/                    # Review rubric (P0-P3 severity)
-│   │   └── roles/reviewer.md             # Review agent persona
+│   │   ├── references/                    # Review dimensions and severity rubric
+│   │   └── roles/forge-reviewer.md        # Review agent persona
 │   ├── forge-address-pr-feedback/SKILL.md # Step 4: Address PR review comments
-│   └── forge-ship/SKILL.md                    # Composite: implement + review in one invocation
+│   └── forge-ship/SKILL.md                # Composite: implement + review in one invocation
 ├── docs/                                  # Project documentation
 ├── AGENTS.md                              # Canonical agent guidance
 ├── CLAUDE.md → AGENTS.md                  # Compatibility symlink
@@ -38,7 +38,7 @@ forge-setup-project → [forge-brainstorm →] forge-create-issue → forge-impl
 
 `forge-brainstorm` is optional — use it when the idea is vague and needs exploration before issue creation.
 
-`forge-ship` is a **composite skill** — it composes implement and reflect into a single invocation, delegating the review step to a sub-agent with fresh context.
+`forge-ship` is a **composite skill** — it composes implement and reflect into a single invocation, delegating review to fresh-context reviewer sub-agents.
 
 - **forge-setup-project** sets up or audits a project's context infrastructure using a three-tier model: `AGENTS.md` as lean hot memory, `docs/` as earned warm memory, and `specs/` (or equivalent) as cold memory, with signal-to-noise scoring for existing guidance. It also supports migrating legacy `CLAUDE.md`-first repos to an `AGENTS.md`-first layout.
 - **forge-brainstorm** investigates the codebase, clarifies the problem through structured questioning, presents approaches with tradeoffs, and produces a plan summary ready for issue creation
@@ -46,7 +46,7 @@ forge-setup-project → [forge-brainstorm →] forge-create-issue → forge-impl
 - **forge-implement** reads an issue, plan file, or free-text description, researches the codebase (optionally via blind scout delegation for complex work), plans vertical implementation phases, and opens a PR
 - **forge-reflect** self-reviews changes (PR, branch diff, or uncommitted) via four parallel reviewer agents (correctness, security, code quality, efficiency) using a P0-P3 severity rubric
 - **forge-address-pr-feedback** fetches unresolved review threads via GraphQL and addresses each one
-- **forge-ship** composes implement and reflect — implementation runs inline, review is delegated to a fresh-context sub-agent, findings are triaged with the user
+- **forge-ship** composes implement and reflect — implementation runs inline, review is delegated to fresh-context reviewer sub-agents, findings are triaged with the user
 
 ## Skill File Format
 
@@ -96,9 +96,8 @@ Every role file has two parts:
 
 ```yaml
 ---
-name: <role-name>           # Kebab-case identifier
+name: <role-name>           # Kebab-case identifier, prefixed with `forge-`
 description: <what it does>  # One sentence
-model-hint: fast | balanced | reasoning  # Advisory — runtimes may ignore
 ---
 ```
 
@@ -106,7 +105,6 @@ model-hint: fast | balanced | reasoning  # Advisory — runtimes may ignore
 |-------|----------|----------|
 | `name` | Yes | Role identifier, referenced in skill delegation steps |
 | `description` | Yes | Describes the role's function |
-| `model-hint` | No | Advisory optimization hint for runtimes that support model selection |
 
 **2. Structured Prompt Body**
 
@@ -118,15 +116,9 @@ The body follows a consistent structure:
 
 The role body is composed with task-specific instructions from the skill. Runtimes that support role-aware delegation load the role as the sub-agent's persona and the skill's blockquote as the task. Runtimes that don't can read the role file inline.
 
-Role files live inside the skill directory that uses them (e.g., `skills/forge-reflect/roles/reviewer.md`). This ensures roles are installed alongside skills regardless of install method (symlink, copy, or package manager). If a role is needed by multiple skills, duplicate it — self-containment beats DRY for distributed prompt files.
+Role files live inside the skill directory that uses them (e.g., `skills/forge-reflect/roles/forge-reviewer.md`). This ensures roles are installed alongside skills regardless of install method (symlink, copy, or package manager). If a role is needed by multiple skills, duplicate it — self-containment beats DRY for distributed prompt files.
 
-### Model Hints
-
-| Hint | Use For | Examples |
-|------|---------|----------|
-| `fast` | High-volume reconnaissance, simple extraction | scout |
-| `balanced` | General-purpose tasks, review, implementation | reviewer |
-| `reasoning` | Deep analysis, complex planning | planner |
+Role names are prefixed with `forge-` (e.g., `forge-scout`, `forge-reviewer`) to keep forge's roles in their own namespace. Subagent runtimes that ship bundled agents under generic names (`scout`, `reviewer`, `worker`) won't shadow forge's roles, and users mixing forge with other skill packs can tell them apart at a glance.
 
 ## Design Decisions
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -55,12 +55,12 @@ When a delegation step benefits from a separated persona, extract it into a **ro
 ```markdown
 #### Research (delegate)
 
-Delegate to a [scout](roles/scout.md) sub-agent that receives only
+Delegate to a [forge-scout](roles/forge-scout.md) sub-agent that receives only
 the questions. If the runtime does not support sub-agents, read the role
 file and answer each question following its rules.
 
 **Inputs provided to sub-agent:**
-- Role: [scout](roles/scout.md)
+- Role: [forge-scout](roles/forge-scout.md)
 - The research questions
 
 **Expected output:** One factual answer per question.
@@ -92,15 +92,15 @@ Conventions shared across skills. When modifying any, update every skill that re
 | Pattern audit | When changing a pattern, update ALL files using it | implement, reflect |
 | Mandatory deferred tracking | Create GitHub issues for all deferred items found in reflection | reflect |
 | Trailing context syntax | Append `-- <additional context>` as the final invocation segment for skills with structured primary input | setup-project, brainstorm, implement, reflect, address-pr-feedback |
-| Review severity | P0-P3 (see reflect/references/review-rubric.md) | reflect |
+| Review severity | P0-P3 (see reflect/references/review-rubric.md) | reflect, ship |
 | Sub-agent delegation | `context: fork` frontmatter + `(delegate)` step marker with role reference or self-contained instructions and inline fallback | brainstorm, implement, reflect |
-| Parallel review agents | `(delegate)` step with parallel sub-agents, each focused on a different review dimension (correctness, security, code quality, efficiency); inline fallback executes sequentially | reflect |
+| Parallel review agents | `(delegate)` step with parallel sub-agents, each focused on a different review dimension (correctness, security, code quality, efficiency); inline fallback executes sequentially | reflect, ship |
 | Stop after questions | Present questions, wait for user confirmation before proceeding | brainstorm |
 | Explore before asking | Check if codebase answers each question before asking the user; provide recommended answers | brainstorm |
 | Divergent sub-agents | `(delegate)` step with parallel sub-agents, each given radically different constraints for approach contrast; inline fallback generates sequentially (see "Writing Delegate Steps") | brainstorm |
 | Vertical slices | Split issues as thin end-to-end paths across all layers; classify as AFK or HITL | create-issue |
-| Reusable roles | Co-located sub-agent personas under each skill's `roles/`; skills reference them instead of inlining persona blocks | implement (scout), reflect (reviewer) |
-| Blind research delegation | `(delegate)` research step using scout role — receives questions but not the ticket; inline fallback answers factually without suggesting implementations | implement |
+| Reusable roles | Co-located sub-agent personas under each skill's `roles/`; skills reference them instead of inlining persona blocks | implement (forge-scout), reflect (forge-reviewer) |
+| Blind research delegation | `(delegate)` research step using forge-scout role — receives questions but not the ticket; inline fallback answers factually without suggesting implementations | implement |
 | Structure outline | High-level vertical phases with verification steps; each phase is a testable end-to-end slice | implement |
 | Durable decisions | Identify architectural decisions that survive implementation changes; keep as plan header | implement |
 | Skill composition | Composite skills reference other skills by path; orchestrators stay lean | ship |

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,7 +54,7 @@ Roles are sub-agent persona definitions that live inside the skill directory tha
 
 1. Create a `roles/` directory inside the skill that will use it
 2. Create a `<role-name>.md` file there
-3. Add YAML frontmatter with `name`, `description`, and optionally `model-hint`
+3. Add YAML frontmatter with `name` and `description`
 4. Write the prompt body: identity, behavior rules, output format, constraints
 5. Update the skill’s delegation step to reference the role
 
@@ -73,8 +73,7 @@ If multiple skills need the same role, duplicate the file into each skill. Self-
 1. Read the role file and the skill that uses it
 2. Make targeted changes
 3. Verify the skill’s delegation step still works with the updated role
-4. Check the `model-hint` is still appropriate
-5. If the same role is duplicated across skills, update all copies
+4. If the same role is duplicated across skills, update all copies
 
 ## Available Commands
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -56,10 +56,10 @@ Write 3–7 targeted questions about how the relevant systems work today, what p
 
 #### Research (delegate)
 
-Delegate to a [scout](roles/scout.md) sub-agent that receives only the questions — not the issue title or body. If the runtime does not support sub-agents, read the role file and answer each question following its rules.
+Delegate to a [forge-scout](roles/forge-scout.md) sub-agent that receives only the questions — not the issue title or body. If the runtime does not support sub-agents, read the role file and answer each question following its rules.
 
 **Inputs provided to sub-agent:**
-- Role: [scout](roles/scout.md)
+- Role: [forge-scout](roles/forge-scout.md)
 - The research questions (not the issue)
 - Access to the full codebase via Read, Grep, Glob, Bash
 

--- a/skills/forge-implement/roles/forge-scout.md
+++ b/skills/forge-implement/roles/forge-scout.md
@@ -1,7 +1,6 @@
 ---
-name: scout
+name: forge-scout
 description: Researches a codebase to answer targeted questions without knowledge of the goal. Provides objective facts for unbiased planning.
-model-hint: fast
 ---
 
 # Scout

--- a/skills/forge-reflect/SKILL.md
+++ b/skills/forge-reflect/SKILL.md
@@ -62,68 +62,17 @@ git diff --name-only HEAD
 
 ### Step 2: Review Changes (delegate)
 
-**Delegate to four parallel sub-agents** using the [reviewer](roles/reviewer.md) role, each assigned one quality dimension. Fresh context eliminates self-review bias — the reviewers have no memory of implementation decisions. If the runtime does not support sub-agents, read the role file and execute each review inline sequentially.
+Read the [review dimensions](references/review-dimensions.md) to obtain the four reviewer checklists.
+
+**Delegate to four parallel sub-agents** using the [forge-reviewer](roles/forge-reviewer.md) role, each assigned one quality dimension. Fresh context eliminates self-review bias — the reviewers have no memory of implementation decisions. If the runtime does not support sub-agents, read the role file and execute the four review dimensions inline sequentially.
 
 Launch all four concurrently. Each sub-agent receives:
-- Role: [reviewer](roles/reviewer.md)
+- Role: [forge-reviewer](roles/forge-reviewer.md)
+- One dimension checklist from [review dimensions](references/review-dimensions.md)
 - [Review rubric](references/review-rubric.md) for severity calibration
 - `AGENTS.md` for project conventions
 - Full diff output and changed file list
 - Any additional context from the user's invocation
-- One dimension checklist (below)
-
-**Agent 1 — Correctness & Patterns:**
-
-> 1. **Logic errors** — off-by-one, wrong operator, incorrect boolean logic, unhandled null/undefined on critical paths
-> 2. **Pattern consistency** — if a pattern was changed, grep for ALL files using it:
->    ```bash
->    grep -rn "<changed-pattern>" <search-root>/
->    ```
->    Flag any files still using the old pattern.
-> 3. **Layer placement** — logic in the right abstraction layer
-> 4. **Configuration** — new env vars documented in sample env or setup docs? Config placed where consumed? No hardcoded credentials? Manual deployment steps captured?
-> 5. **Leaky abstractions** — exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
-
-**Agent 2 — Security:**
-
-> 1. **Injection** — SQL, command, XSS, template injection — anywhere user-controlled input reaches a query, shell command, or rendered output without sanitization
-> 2. **Authentication & authorization** — new endpoints or operations missing auth checks; privilege escalation paths; role checks that can be bypassed
-> 3. **Secrets & credentials** — API keys, tokens, passwords hardcoded or logged; secrets committed to version control; credentials in error messages or stack traces
-> 4. **Input validation** — missing or insufficient validation on external input; path traversal via user-controlled file paths; unbounded input sizes that enable DoS
-> 5. **SSRF & external requests** — user-controlled URLs passed to HTTP clients, DNS rebinding risks, internal service endpoints reachable via crafted input
-> 6. **Race conditions** — time-of-check to time-of-use (TOCTOU) gaps that create security windows; concurrent access without proper locking on security-sensitive state
-> 7. **Cryptography** — weak algorithms, hardcoded IVs/salts, custom crypto instead of established libraries, insecure random number generation for security-sensitive values
-> 8. **Information leakage** — verbose error messages exposing internals, stack traces returned to clients, debug endpoints left enabled, sensitive data in logs
-> 9. **Insecure deserialization** — deserializing untrusted data without validation; formats that allow code execution (pickle, YAML load, eval)
-> 10. **Dependency risk** — new dependencies with known CVEs; pinned versions with known vulnerabilities; unnecessary new attack surface from added packages
-
-**Agent 3 — Code Reuse & Quality:**
-
-> 1. **Redundant implementations** — search the codebase for existing helpers, utilities, or shared modules that already solve the same problem before accepting new code
-> 2. **Extraction opportunities** — repeated logic across the diff, or inline code that reimplements what a shared module already provides (string manipulation, path handling, type guards, environment checks)
-> 3. **Structural bloat** — functions growing beyond a screenful, parameter lists growing instead of restructuring, state that duplicates what's already tracked elsewhere
-> 4. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
-> 5. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
-> 6. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
-
-**Agent 4 — Efficiency, Tests & Docs:**
-
-> **Efficiency:**
-> 1. **Wasted cycles** — redundant computations, duplicate I/O or network calls, N+1 query patterns
-> 2. **Sequential bottlenecks** — independent operations that could run concurrently but are chained
-> 3. **Hot-path impact** — new synchronous work on startup, request, or render critical paths
-> 4. **Phantom updates** — state mutations that fire without checking whether anything actually changed, triggering unnecessary downstream work
-> 5. **Premature existence checks** — verifying a resource exists before operating on it; prefer operating and handling the error (skip if already flagged as a security race condition by another reviewer)
-> 6. **Resource leaks** — unbounded collections, missing cleanup handlers, dangling event listeners
-> 7. **Over-fetching** — reading entire resources when a slice would suffice; loading all records to filter for one
->
-> **Tests & Documentation:**
-> 8. **Test coverage** — corresponding test files exist? Error handling branches covered? Edge cases for new public functions?
-> 9. **Documentation** — changes require updates to `docs/*.md`, `AGENTS.md`, code comments, or README? Grep docs for stale references to anything removed or renamed:
->    ```bash
->    grep -rn "<removed-term>" docs/
->    ```
-> 10. **Cleanup** — no temporary debug logging, commented-out code, untracked TODOs, unused imports, or hardcoded values that should be constants
 
 **Expected output:** Structured findings per agent, grouped by file with severity tags (P0/P1/P2).
 

--- a/skills/forge-reflect/references/review-dimensions.md
+++ b/skills/forge-reflect/references/review-dimensions.md
@@ -1,0 +1,56 @@
+# Review Dimensions
+
+Four quality dimensions for parallel review. Each reviewer agent receives one dimension checklist.
+
+## Agent 1 — Correctness & Patterns
+
+1. **Logic errors** — off-by-one, wrong operator, incorrect boolean logic, unhandled null/undefined on critical paths
+2. **Pattern consistency** — if a pattern was changed, grep for ALL files using it:
+   ```bash
+   grep -rn "<changed-pattern>" <search-root>/
+   ```
+   Flag any files still using the old pattern.
+3. **Layer placement** — logic in the right abstraction layer
+4. **Configuration** — new env vars documented in sample env or setup docs? Config placed where consumed? No hardcoded credentials? Manual deployment steps captured?
+5. **Leaky abstractions** — exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+
+## Agent 2 — Security
+
+1. **Injection** — SQL, command, XSS, template injection — anywhere user-controlled input reaches a query, shell command, or rendered output without sanitization
+2. **Authentication & authorization** — new endpoints or operations missing auth checks; privilege escalation paths; role checks that can be bypassed
+3. **Secrets & credentials** — API keys, tokens, passwords hardcoded or logged; secrets committed to version control; credentials in error messages or stack traces
+4. **Input validation** — missing or insufficient validation on external input; path traversal via user-controlled file paths; unbounded input sizes that enable DoS
+5. **SSRF & external requests** — user-controlled URLs passed to HTTP clients, DNS rebinding risks, internal service endpoints reachable via crafted input
+6. **Race conditions** — time-of-check to time-of-use (TOCTOU) gaps that create security windows; concurrent access without proper locking on security-sensitive state
+7. **Cryptography** — weak algorithms, hardcoded IVs/salts, custom crypto instead of established libraries, insecure random number generation for security-sensitive values
+8. **Information leakage** — verbose error messages exposing internals, stack traces returned to clients, debug endpoints left enabled, sensitive data in logs
+9. **Insecure deserialization** — deserializing untrusted data without validation; formats that allow code execution (pickle, YAML load, eval)
+10. **Dependency risk** — new dependencies with known CVEs; pinned versions with known vulnerabilities; unnecessary new attack surface from added packages
+
+## Agent 3 — Code Reuse & Quality
+
+1. **Redundant implementations** — search the codebase for existing helpers, utilities, or shared modules that already solve the same problem before accepting new code
+2. **Extraction opportunities** — repeated logic across the diff, or inline code that reimplements what a shared module already provides (string manipulation, path handling, type guards, environment checks)
+3. **Structural bloat** — functions growing beyond a screenful, parameter lists growing instead of restructuring, state that duplicates what's already tracked elsewhere
+4. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
+5. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
+6. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
+
+## Agent 4 — Efficiency, Tests & Docs
+
+**Efficiency:**
+1. **Wasted cycles** — redundant computations, duplicate I/O or network calls, N+1 query patterns
+2. **Sequential bottlenecks** — independent operations that could run concurrently but are chained
+3. **Hot-path impact** — new synchronous work on startup, request, or render critical paths
+4. **Phantom updates** — state mutations that fire without checking whether anything actually changed, triggering unnecessary downstream work
+5. **Premature existence checks** — verifying a resource exists before operating on it; prefer operating and handling the error (skip if already flagged as a security race condition by another reviewer)
+6. **Resource leaks** — unbounded collections, missing cleanup handlers, dangling event listeners
+7. **Over-fetching** — reading entire resources when a slice would suffice; loading all records to filter for one
+
+**Tests & Documentation:**
+8. **Test coverage** — corresponding test files exist? Error handling branches covered? Edge cases for new public functions?
+9. **Documentation** — changes require updates to `docs/*.md`, `AGENTS.md`, code comments, or README? Grep docs for stale references to anything removed or renamed:
+   ```bash
+   grep -rn "<removed-term>" docs/
+   ```
+10. **Cleanup** — no temporary debug logging, commented-out code, untracked TODOs, unused imports, or hardcoded values that should be constants

--- a/skills/forge-reflect/roles/forge-reviewer.md
+++ b/skills/forge-reflect/roles/forge-reviewer.md
@@ -1,7 +1,6 @@
 ---
-name: reviewer
+name: forge-reviewer
 description: Reviews code changes for a specific quality dimension using severity-tagged findings. Used by skills that delegate parallel review with fresh context.
-model-hint: balanced
 ---
 
 # Reviewer

--- a/skills/forge-ship/SKILL.md
+++ b/skills/forge-ship/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: forge-ship
-description: End-to-end implementation and self-review in a single invocation. Implements from a GitHub issue, plan file, or free-text description, then delegates review to a fresh-context sub-agent. Use when the user wants to implement and review without manual handoff between skills.
+description: End-to-end implementation and self-review in a single invocation. Implements from a GitHub issue, plan file, or free-text description, then delegates review to fresh-context reviewer sub-agents. Use when the user wants to implement and review without manual handoff between skills.
 disable-model-invocation: true
 ---
 
 # Ship
 
-Implement end to end — code it, review it, ship it. Implementation runs in the current session; review is delegated to a sub-agent with fresh context for unbiased findings.
+Implement end to end — code it, review it, ship it. Implementation runs in the current session; review is delegated to fresh-context reviewer sub-agents for unbiased findings.
 
 ## Input
 
@@ -14,7 +14,7 @@ Primary input: a GitHub issue, a plan file, or a free-text description.
 
 Optional last parameter: `-- <additional context>`
 
-Interpret `$ARGUMENTS` the same way as [forge-implement](../forge-implement/SKILL.md):
+Interpret `$ARGUMENTS` the same way as `forge-implement`:
 - `<issue-number>` — GitHub issue
 - `<issue-url>` — GitHub issue URL
 - `<file-path>` — path to a plan, roadmap, or spec file
@@ -41,7 +41,7 @@ Do not produce the implementation summary yet — the review will inform the fin
 
 ### Step 2: Prepare Review Context
 
-Collect the materials the reviewer needs:
+Collect the materials the reviewers need:
 
 ```bash
 git fetch origin
@@ -50,11 +50,14 @@ git diff origin/$DEFAULT_BRANCH...HEAD
 git diff --name-only origin/$DEFAULT_BRANCH...HEAD
 ```
 
-Read [forge-reflect](../forge-reflect/SKILL.md) to obtain the four review dimensions and their checklists (Correctness & Patterns, Security, Code Reuse & Quality, Efficiency & Tests & Docs).
+Read the shared review references from `forge-reflect`:
+- [Review dimensions](../forge-reflect/references/review-dimensions.md) — the four reviewer checklists
+- [Review rubric](../forge-reflect/references/review-rubric.md) — severity calibration
 
-Compose a **self-contained review task** that includes:
-- The review process and four-dimension checklists from forge-reflect (Step 2)
-- The [review rubric](../forge-reflect/references/review-rubric.md) for severity calibration
+Compose **four self-contained review tasks** — one per dimension — that each include:
+- The [forge-reviewer role](../forge-reflect/roles/forge-reviewer.md)
+- One dimension checklist from [review dimensions](../forge-reflect/references/review-dimensions.md)
+- The [review rubric](../forge-reflect/references/review-rubric.md)
 - The project's `AGENTS.md` content
 - The full diff and changed file list
 - Branch name and PR number
@@ -62,19 +65,19 @@ Compose a **self-contained review task** that includes:
 
 ### Step 3: Review (delegate)
 
-**Delegate to a sub-agent for review.** Fresh context eliminates self-review bias — the reviewer has no memory of implementation decisions.
+**Delegate to four parallel sub-agents for review.** Fresh context eliminates self-review bias — each reviewer has no memory of implementation decisions and focuses on one quality dimension.
 
 Use the first available delegation mechanism:
 
-1. **`subagent` tool** (e.g., Pi with [pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents)): spawn with `agent: "reviewer"` and the composed review task. The sub-agent runs autonomously in a separate session with fresh context.
-2. **Runtime context forking** (e.g., Claude Code Task tool): delegate with fresh context.
-3. **Inline fallback**: if no sub-agent mechanism is available, read the [reviewer role](../forge-reflect/roles/reviewer.md) and execute the four review dimensions sequentially in the current context.
+1. **`subagent` tool** (e.g., Pi with [pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents)): spawn four concurrent sub-agents with `agent: "forge-reviewer"`, one for each dimension task.
+2. **Runtime context forking** (e.g., Claude Code Task tool): delegate four fresh-context review tasks in parallel.
+3. **Inline fallback**: if no sub-agent mechanism is available, read the [forge-reviewer role](../forge-reflect/roles/forge-reviewer.md) and execute the four review dimensions sequentially in the current context.
 
-Wait for the review results before proceeding.
+Wait for **all four** review results before proceeding.
 
 ### Step 4: Triage Findings
 
-Aggregate and deduplicate review findings.
+Aggregate and deduplicate findings from all four review agents.
 
 **In attended mode (default):** present each finding to the user with a recommendation:
 
@@ -121,7 +124,7 @@ Report implementation and review results together.
 ## Guidelines
 
 - **Implementation runs inline** — user interaction for plan approval is preserved (unless `--unattended`)
-- **Review runs in fresh context** — sub-agent has no memory of implementation decisions
+- **Review runs in fresh context** — four reviewer sub-agents each cover one dimension without implementation memory
 - **Don't skip the review** — even if implementation felt clean, review catches blind spots
 - **Triage with the user** — don't auto-fix findings without asking (unless `--unattended`, which uses severity-based auto-triage)
 - **Graceful degradation** — the `subagent` tool is provided by external extensions; the skill works without it via inline fallback, but fresh-context review requires sub-agent support
@@ -129,7 +132,7 @@ Report implementation and review results together.
 
 ## Related Skills
 
-**Components:** Composes [forge-implement](../forge-implement/SKILL.md) and [forge-reflect](../forge-reflect/SKILL.md).
+**Components:** Composes `forge-implement` and `forge-reflect`.
 **After peer review:** Use `forge-address-pr-feedback` to address reviewer comments.
 
 ## Example Usage


### PR DESCRIPTION
## Summary

Two related cleanups + one new file:

**Role namespace + checklist dedupe**
- Rename role files to `forge-scout.md` / `forge-reviewer.md` to keep forge's roles in their own namespace
- Extract review-dimension checklists from `forge-reflect/SKILL.md` into `references/review-dimensions.md`; `forge-ship` now references the same file via path instead of duplicating
- Remove the obsolete `model-hint` frontmatter field and the "Model Hints" subsection in `architecture.md`
- Update all SKILL.md and docs cross-references

**`CONTEXT.md` (new)**
Shared vocabulary used across forge skills. Defines: Issue tracker, Issue, Plan, Vertical slice, AFK/HITL, Reflection, Finding, Deferred item, Composite skill, Inline fallback, Self-containment, Pattern audit, Quality gates, Attended/unattended mode, Trailing context, and the Three-tier context model. Structure follows the Pocock-style Language / Relationships / Flagged ambiguities split. Contents describe forge's current reality — provider abstraction across Linear / markdown trackers is noted as roadmap, not present-day support. Linked from AGENTS.md and README.md docs indexes.

## Test plan

- [ ] `/forge-reflect` still spawns four parallel reviewers with the same dimension checklists (now loaded from `references/review-dimensions.md`)
- [ ] `/forge-ship` review step reads the same `review-dimensions.md` and `review-rubric.md` as `forge-reflect`
- [ ] `/forge-implement` scout delegation references `roles/forge-scout.md`
- [ ] `grep -rn "roles/reviewer\|roles/scout" skills/ docs/` returns no hits
- [ ] AGENTS.md and README.md docs tables both link `CONTEXT.md`