### PR TITLE
refactor(create-issue): extract slicing and AFK/HITL philosophy to companions

### DIFF
--- a/skills/forge-create-issue/SKILL.md
+++ b/skills/forge-create-issue/SKILL.md
@@ -48,21 +48,19 @@ Let the user choose or combine approaches.
 
 ### Step 4: Assess Scope
 
-Evaluate if this should be one issue or multiple.
+Evaluate if this should be one Issue or multiple.
 
 **Split when:** distinct deliverables, different codebase areas, parallelizable work, or effort exceeds 1-2 days.
 
 **Keep together when:** tightly coupled changes or splitting adds coordination overhead.
 
-**When splitting, use vertical slices** — each issue should be a thin end-to-end path across all affected layers (data, logic, UI, tests), not a horizontal layer slice. Each slice must be independently verifiable.
+When splitting, slice **vertically** — each Issue is a thin end-to-end path through every layer the feature touches. See [vertical-slicing.md](references/vertical-slicing.md) for what makes a slice thin, common failure modes (horizontal slices in disguise, slices too thick to ship), and worked examples.
 
-Classify each issue:
-- **AFK** (Away From Keyboard) — can be implemented by an agent without human intervention
-- **HITL** (Human In The Loop) — requires architectural decisions, design review, or external input
+Classify each Issue as **AFK** (away-from-keyboard, autonomous agent execution) or **HITL** (human-in-the-loop, requires judgment during execution). See [afk-vs-hitl.md](references/afk-vs-hitl.md) for the classification test ("if the human disappears, where does the agent stall?"), common mis-classifications, and the mode lock-in rule.
 
-Order issues by dependency — earlier slices unblock later ones.
+Order Issues by dependency — earlier slices unblock later ones.
 
-If splitting makes sense, offer: single issue, multiple linked issues, or epic with sub-issues.
+If splitting makes sense, offer: single Issue, multiple linked Issues, or epic with sub-issues.
 
 ### Step 5: Draft the Issue
 

--- a/skills/forge-create-issue/references/afk-vs-hitl.md
+++ b/skills/forge-create-issue/references/afk-vs-hitl.md
@@ -1,0 +1,56 @@
+# AFK vs HITL
+
+How to classify whether an Issue can be implemented autonomously by an agent (AFK) or requires human judgment during execution (HITL).
+
+## Definitions
+
+**AFK** (away-from-keyboard) — the Issue is fully specified. Every decision an implementer needs to make is either already in the Issue or discoverable from the codebase. An agent can pick this up, implement it, run quality gates, open a PR, and wait for review. The human's involvement is reviewing the PR, not steering the implementation.
+
+**HITL** (human-in-the-loop) — the Issue requires judgment calls during implementation that can't be made from the Issue and the codebase alone. An agent picking this up will get partway through and stall on a question that needs a human to answer.
+
+## The core test
+
+> *If the human disappears the moment the agent picks up this Issue, where does the agent get stuck?*
+
+If the answer is "nowhere — the agent finishes, opens a PR, the PR sits there until I review it," it's AFK.
+
+If the answer is "the agent will stall when it hits decision X, because X depends on context the Issue doesn't capture," it's HITL.
+
+Apply this test honestly. The instinct is to label things AFK because AFK feels lighter. Resist that instinct — a misclassified AFK Issue creates more work than an honest HITL Issue, because the agent burns a session before stalling and you have to recover.
+
+## What makes something HITL
+
+Common patterns that imply HITL:
+
+- **Architectural decision still open.** "Should this be a queue or a cron job?" If the Issue doesn't pick one (and the codebase doesn't imply one), it's HITL.
+- **Tradeoff between user-visible alternatives.** "Faster but uglier loading state vs. slower but smoother." Someone has to choose, and the choice is taste, not technical.
+- **External coordination.** "We need to align with the mobile team on the API shape." Until that conversation happens, the implementation can't be picked.
+- **Missing source of truth.** "What's the right copy for this empty state?" If the Issue doesn't have it and there's no design system to consult, it's HITL.
+- **Compliance / legal / security review required.** Any change that touches PII, auth, billing, or the like, where someone other than the implementer has to sign off mid-flight.
+- **Refactor with no test coverage.** The agent can't verify it didn't break anything, so each step requires a human eyeballing diff-vs-behavior.
+
+## What makes something AFK
+
+If all of these hold, the Issue is AFK:
+
+- **Acceptance criteria are testable.** Each criterion can be verified by running a command, reading an output, or executing a flow — not by asking "does this feel right?"
+- **The chosen approach is in the Issue.** Not just the problem; the *what to do about it*. The Implementation Constraints section is doing real work.
+- **Scope is contained.** The Issue doesn't say "and any related issues you find while in there" — it says "do exactly this."
+- **No external blockers.** No "waiting on X to merge their PR first." No "need feedback from Y before implementing."
+- **Test coverage exists or the Issue says how to add it.** The agent can verify behavior either through existing tests or by writing the tests called for.
+
+## Common mis-classifications
+
+**"It's small, so it's AFK."** Smallness ≠ specifiability. A two-line change with hidden ambiguity is HITL. A 500-line refactor with crystal-clear acceptance criteria is AFK.
+
+**"The implementer can decide."** Sometimes true (taste-neutral choices like "use the existing utility instead of writing a new one"). Sometimes false ("decide whether to break the public API" is not the implementer's call). When in doubt, lift the decision into the Issue.
+
+**"We'll figure it out as we go."** This is HITL with a friendlier name. AFK requires the figuring out to happen *before* the agent picks the Issue, not during.
+
+**"It's HITL because the codebase is messy."** A messy codebase doesn't change the classification — it changes the *risk* of an AFK Issue going wrong. Mitigation: tighter acceptance criteria, more explicit Implementation Constraints, or explicit instruction to stop and ask if something unexpected appears. A well-specified Issue in a messy codebase is still AFK.
+
+## Mode lock-in
+
+The classification is set when the Issue is *created*, not when it's picked up. A change that turns an AFK Issue into HITL during implementation (e.g., the agent discovers an architectural ambiguity that wasn't visible at creation time) means the Issue should be paused, the new ambiguity resolved, and the Issue updated — not silently continued as HITL.
+
+This sounds bureaucratic. The reason for the rule: an Issue that quietly becomes HITL mid-flight produces a PR that mixes "the agent's implementation" with "decisions the human made during implementation," and the audit trail is destroyed. Pausing preserves the trail.

--- a/skills/forge-create-issue/references/vertical-slicing.md
+++ b/skills/forge-create-issue/references/vertical-slicing.md
@@ -1,0 +1,58 @@
+# Vertical Slicing
+
+How to split work into shippable, verifiable pieces.
+
+## What a vertical slice is
+
+A vertical slice is a thin path through every layer the feature touches — data, logic, UI, tests — for **one narrow scenario**. End-to-end, but minimal in scope.
+
+A horizontal slice is the opposite: an entire layer (e.g., "the database schema for everything") with nothing on top of it. Horizontal slices ship nothing useful on their own; a vertical slice can be merged, deployed, and verified in isolation.
+
+## Why slice vertically
+
+1. **Each slice is independently shippable.** A feature that fails in production at slice 3 doesn't take slices 1 and 2 with it.
+2. **Integration issues surface at slice 1, not slice N.** Wiring problems, type mismatches, and missing infrastructure all reveal themselves the first time you go end-to-end. Horizontal slicing hides them until the end, when fixing them is expensive.
+3. **You can demo something.** A vertical slice produces a thing the user (or stakeholder) can see and react to. A horizontal slice produces an internal artifact nobody can evaluate.
+4. **Testability is built in.** End-to-end verification exists from slice 1. You aren't adding tests later as an afterthought — you're constraining the slice to fit a test that already exists or one you write alongside.
+
+## How to identify slice boundaries
+
+For a feature, ask: *what is the smallest scenario that touches every layer this feature needs?*
+
+- **One specific case, not the whole feature.** "Cart shows totals for one fixed-currency order with one tax rule" is a slice. "Cart totaling system" is not.
+- **One persona, not all personas.** "Admin can mark an issue as resolved" is a slice. "Issue resolution workflow" is several slices.
+- **One data path, not all data paths.** "Read flow for cached records" is a slice. "Caching layer" is not.
+
+After the first slice ships, the next slice extends in *one* direction: more cases, more personas, more data paths, more error handling — pick one axis per slice.
+
+## Common failure modes
+
+**Horizontal slices in disguise.** "Set up the database schema for cart items" is horizontal even if you call it a vertical slice. Test: can you ship this slice and have a user see something change? If no, it's not vertical.
+
+**Slices that share infrastructure changes.** If slice 1 requires "add the new auth middleware" and slice 2 also requires "add the new auth middleware", the middleware is its own pre-slice (or part of slice 1 with explicit acceptance) — not a shared dependency between two pretend-vertical slices.
+
+**Slices too thick to ship.** A "thin" slice should fit in one PR an agent can complete in 1–2 days. If a slice has 6 acceptance criteria and touches 4 services, it's not thin. Split again.
+
+**Slices that don't actually go end-to-end.** The data layer slice plus "we'll add UI later" is two horizontal slices renamed. The slice must include UI (or whatever the user-visible surface is) from day one.
+
+**Implicit dependencies between slices.** Slice 2 should not silently require slice 1 if you didn't say so. Order issues by dependency and state the dependency in the issue body.
+
+## Examples
+
+**Feature**: dark mode toggle for a settings page.
+
+Vertical slices, in order:
+
+1. **Toggle exists, persists in localStorage, applies a theme variable to one component.** End-to-end for one component, no backend, no preference syncing.
+2. **Toggle preference syncs to user record on the backend.** Builds on slice 1; adds the persistence layer.
+3. **All components respect the theme variable.** Builds on slices 1–2; expands surface area without touching infrastructure.
+
+Horizontal slices (avoid):
+
+1. ~~Backend user-preference schema~~ — ships nothing user-visible.
+2. ~~Theme variable system across all components~~ — no toggle to drive it.
+3. ~~Settings UI for preferences~~ — toggle exists but does nothing.
+
+## Decision
+
+When splitting work, the question to ask is not *"what are the layers?"* — it's *"what's the smallest end-to-end thing I could ship and verify?"* The first question yields horizontal slices; the second yields vertical ones.


### PR DESCRIPTION
## Summary

Pilot of the progressive-disclosure pattern on `forge-create-issue`. Step 4's inline philosophy on vertical slicing and AFK/HITL classification moves into companion docs that load on demand. SKILL.md keeps the procedure and decision points; the philosophy lives where it can be expanded without bloating the always-loaded skill body.

**New companions** (~58 lines each):
- \`references/vertical-slicing.md\` — what makes a slice thin, why slice vertically, common failure modes (horizontal slices in disguise, slices too thick to ship, implicit dependencies between slices), and a worked example for a dark-mode toggle
- \`references/afk-vs-hitl.md\` — the core test ('if the human disappears, where does the agent stall?'), what makes Issues HITL vs AFK, common mis-classifications ('it's small, so it's AFK' is a trap), and the mode lock-in rule

**SKILL.md Step 4** shrinks to procedure + pointers. The Issue-tracker capitalization in this section is also normalized to follow CONTEXT.md.

## Why

Two motivations:

1. Today the procedure ('split when X, classify as Y') and the philosophy ('what makes vertical *vertical*, what makes AFK *AFK*') sit in the same paragraph. Agents read the philosophy on every invocation regardless of whether they need it. Companion docs flip that — load the deep version only when the agent hits the decision.

2. The companions are also a place to articulate craft opinion that's currently scattered or unsaid (worked examples, failure modes, the mode-lock-in rule). They double as the kind of opinionated essay the user has had to give verbally on past projects.

This is a pilot. If the pattern feels right, \`forge-implement\` (181 lines, more philosophy embedded around pattern audit and quality gates) and \`forge-brainstorm\` (interview methodology) are the next candidates.

## Test plan

- [ ] \`/forge-create-issue\` Step 4 still produces correct splitting + classification behavior, now reading companions when the agent hits a decision
- [ ] Companions read like opinionated essays (failure modes, examples, judgment frames) rather than watered-down skill sections
- [ ] No other skill or doc cross-links to these companions (self-containment preserved)
- [ ] CONTEXT.md AFK/HITL definition stays brief; deep version lives only in the skill's companion