### PR TITLE
refactor(implement): extract phasing, pre-flight, and pattern-audit philosophy

### DIFF
--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -67,7 +67,7 @@ Delegate to a [forge-scout](roles/forge-scout.md) sub-agent that receives only t
 
 From the research (or your own codebase exploration for straightforward issues), create a plan:
 - Durable decisions
-- **Structure outline** — order work as vertical phases; each phase is a thin end-to-end slice across all affected layers with a verification step
+- **Structure outline** — order work as vertical phases, each spanning all affected layers with a verification step. See [vertical-phases.md](references/vertical-phases.md) for what makes a phase verifiable, common failure modes (layered phases in disguise, phases without verification), and worked examples.
 - Files to create or modify
 - Scope boundaries (what will NOT change)
 
@@ -90,11 +90,7 @@ When working from a plan file or free-text (no issue number), use a descriptive 
 
 Read AGENTS.md first. Follow project conventions strictly.
 
-**Pre-flight checks** — before writing feature code:
-- Run code generators (if the project uses them) and verify generated artifacts are current
-- Grep for where config is consumed before placing new config values
-- Verify external services and APIs are accessible
-- Confirm required environment variables, secrets, and credentials are available
+**Pre-flight checks** — before writing feature code, validate the foundation: codegen current, config readers grep'd, external services reachable, env vars/secrets present, existing patterns identified. See [pre-flight.md](references/pre-flight.md) for the rationale, what each check costs vs catches, and when a check can be skipped.
 
 **Follow the structure outline from Step 2.** Each phase is a vertical slice — implement it end to end and verify before starting the next phase. Use TodoWrite to track progress through phases.
 
@@ -119,11 +115,13 @@ Refs #<ISSUE_NUMBER>"  # omit Refs line when there is no issue
 
 ### Step 5: Pattern Consistency Audit
 
-If you changed a pattern (error handling, component structure, API convention), search for ALL files using that pattern and update them too:
+If you changed a pattern (error handling, component structure, API convention), grep for every other file using the old pattern and update them too:
 
 ```bash
 grep -rn "<pattern>" <search-root>/
 ```
+
+See [pattern-audit.md](references/pattern-audit.md) for what counts as "the pattern", how to scope the search, distinguishing missed updates from intentional drift, and worked examples.
 
 ### Step 6: Update Documentation
 

--- a/skills/forge-implement/references/pattern-audit.md
+++ b/skills/forge-implement/references/pattern-audit.md
@@ -1,0 +1,99 @@
+# Pattern Consistency Audit
+
+When a pattern changes in a diff, find every other place using the old pattern and update them too. The audit is forge's defense against quiet drift — a codebase where two ways of doing the same thing coexist because someone changed one and didn't notice the other.
+
+## The principle
+
+A "pattern" is any shape repeated across the codebase: an error-handling style, a component structure, an API call convention, a config-key naming scheme, an import order rule. When you change the shape in one place, every other place using the old shape is now *out of step* with the codebase's intent.
+
+Out-of-step usages don't break anything in the moment. They cause future bugs:
+
+- A new contributor reads the codebase and finds two patterns. They have to guess which is current. If they pick wrong, they propagate the old shape further.
+- A bug found in the new pattern's implementation gets fixed. The same bug in the old pattern, in 11 other files, doesn't get fixed.
+- Reviewers reading a future PR can't tell whether a usage of the old pattern is "legacy not yet migrated" or "the right shape for this case." Pattern audits are how you make sure the answer is always the former.
+
+## When to audit
+
+Run the audit at two points:
+
+1. **During implementation** (Step 5) — the moment you change a pattern in a diff, before continuing.
+2. **During reflection** (forge-reflect's Correctness & Patterns dimension) — verifying the implementation didn't miss anything.
+
+Doing it twice is not redundant: the first catches the cases the implementer can see; the second catches the cases the implementer was too close to see.
+
+## What counts as "the pattern"
+
+This is the judgment call. The pattern is the *shape* you changed, not the specific text.
+
+If you renamed `getUserById` to `fetchUser`, the pattern is *not* the string `getUserById` — it's the function being called. Grep needs to match call sites, including ones where the import is renamed locally.
+
+If you changed how errors are raised in one module from `throw new Error(...)` to `throw new DomainError(...)`, the pattern is the error-throwing convention for that module's domain. Other domains might (correctly) still throw `Error`. The audit is scoped to the domain.
+
+If you added a new prop to a component and changed how it's passed (e.g., explicit prop → derived from context), the pattern is the calling convention for that component. Audit every call site.
+
+A useful test: *if a future contributor saw the new shape and the old shape side by side, would they think one was wrong?* If yes, the old shape needs updating. If no (e.g., they're correctly different in different contexts), the audit is complete.
+
+## How to scope the search
+
+Match the search root to the pattern's scope.
+
+- **Whole-repo pattern** (e.g., import ordering, error-throwing convention): grep across the entire repo.
+- **Module-scoped pattern** (e.g., how the auth module handles invalid tokens): grep within that module's directory only.
+- **Layer-scoped pattern** (e.g., how API routes register middleware): grep within the API layer only.
+
+Over-scoping the search produces false positives ("this file uses the old shape but it's a different domain"). Under-scoping misses real cases. When unsure, start narrow and widen if the narrow scope finds clean matches.
+
+```bash
+# Whole repo
+grep -rn "<old-pattern>" .
+
+# Module
+grep -rn "<old-pattern>" src/auth/
+
+# Layer
+grep -rn "<old-pattern>" src/server/routes/
+```
+
+## Distinguishing missed updates from intentional drift
+
+Not every match is something to update. Two cases warrant leaving the old shape:
+
+1. **Different domain, same surface text.** The string matches but the meaning is different. Example: `Error` is thrown in two unrelated modules; one was changed; the other is correctly unchanged.
+2. **Deprecated but still in use.** The old shape is being phased out gradually; updating it now expands scope beyond the current Issue.
+
+In both cases, the audit's *output* should still mention the match, even if no update happens. Reviewer needs to see "I considered this and decided to leave it" rather than "I didn't notice this." A one-line comment in the PR body is enough:
+
+> Pattern audit: 4 call sites updated; 2 left unchanged in `src/legacy/` per the deprecation policy.
+
+## Common failure modes
+
+**Grepping for the literal text instead of the pattern.** Renaming `userId` to `accountId` and grepping for `userId` misses call sites that aliased the import. Pattern audits care about the *thing*, not the spelling.
+
+**Searching the wrong scope.** A whole-repo grep for a layer-scoped pattern produces a 200-line output of false positives. The audit gets abandoned.
+
+**Stopping at the first batch.** Updating the matches is one pass. Re-grep after updating to confirm zero matches remain. Sometimes an update introduces new usages of the old shape (a copy-paste during the migration). The second pass catches it.
+
+**Mistaking "no matches" for "audit complete."** If grep finds nothing, the pattern might be expressed differently. Try a synonym, an AST-shaped search, or an alternate spelling. Zero matches *can* mean the pattern audit has nothing to do — but only if you've checked the pattern was searchable in the first place.
+
+**Skipping the audit because the change "feels small."** Small changes are exactly the ones whose pattern audits get skipped. They're also exactly the ones that quietly create drift. Run the grep regardless of perceived size.
+
+## Examples
+
+**Change**: renamed an internal function `validateInput` to `parseInput` (the contract changed from "throws on invalid" to "returns a Result type").
+
+Audit:
+1. Grep `validateInput` whole-repo (function name is unique enough for a wide search).
+2. For each match, decide: still calls validateInput? Update to parseInput. Calls something else with the same name? Leave alone (verify it's truly different).
+3. Re-grep `validateInput` after updates. Zero matches → audit complete.
+
+**Change**: changed the error response shape on REST handlers from `{ error: string }` to `{ code: string, message: string }`.
+
+Audit:
+1. Grep the API layer (`src/server/routes/`) for `error:` to find handlers still emitting the old shape.
+2. Grep the client (`src/client/api/`) for `.error` to find consumers still reading the old shape.
+3. Update both sides. Server tests verify shape; client tests verify parsing.
+4. Re-grep both sides after updates.
+
+## Decision
+
+The pattern audit is a 30-second grep that prevents months of slow-burning inconsistency. **Run it every time you change a pattern, even when the change feels small.** A short audit with confirmed zero matches is the right answer most of the time — the discipline isn't *finding* lots of cases, it's *checking*.

--- a/skills/forge-implement/references/pre-flight.md
+++ b/skills/forge-implement/references/pre-flight.md
@@ -1,0 +1,107 @@
+# Pre-flight Checks
+
+Validate the foundation before writing feature code. Pre-flight catches the failures that look like "I built the thing and nothing works" — and reveals them in seconds instead of hours.
+
+## The principle
+
+Implementation depends on a foundation: generated artifacts, configuration values, external services, environment variables, credentials. When the foundation is wrong or absent, feature code fails in confusing ways that *look like bugs in the feature* but are actually bugs in the foundation.
+
+Pre-flight is the discipline of validating the foundation *before* the feature exists, so a foundation failure produces a clear "the foundation is broken" signal instead of a confusing "the feature doesn't work" signal.
+
+The cost is small (minutes, sometimes seconds). The cost of skipping it is the worst kind of debugging session: hours spent staring at correct feature code that fails because of a silently misconfigured foundation.
+
+## What to check
+
+Run all of these *before* the first line of feature code:
+
+### 1. Code generators
+
+If the project uses code generators (typed clients, schema bindings, route stubs, ORM models), run them and verify the output is current.
+
+```bash
+# whatever the project's codegen command is
+npm run codegen
+git diff --stat -- generated/
+```
+
+If generators emit a diff, the foundation is stale. Either commit the regenerated artifacts (in their own commit, before the feature work) or investigate why they drifted. Building feature code on stale generated artifacts means the type-checker and the tests are lying to you about what the system actually does.
+
+### 2. Config placement
+
+When adding a new configuration value, *grep for where similar config is consumed before placing the new value*.
+
+```bash
+grep -rn "<EXISTING_RELATED_CONFIG_KEY>" src/
+```
+
+Config that's defined but never read is the most common silent failure. Config readers usually live in one or two files; placing a new value in the wrong file means the system *parses* it but never *uses* it. The feature appears to be built; it has no effect.
+
+### 3. External services and APIs
+
+If the work depends on an external service (a SaaS API, an internal microservice, a database, a third-party SDK), verify it's reachable and authenticated *before* writing the integration code.
+
+```bash
+# Health-check the external dependency in whatever way is cheapest
+curl -fsSL "$EXTERNAL_API_URL/health"
+# or: ping the actual endpoint with a known-good request
+```
+
+Wiring code against a service you've never successfully called is wiring against vapor. Half the integration bugs are in the wiring; the other half are in the service being unavailable, returning a different shape than documented, or requiring authentication you don't have. Find out which class of bug you have before writing 200 lines.
+
+### 4. Environment variables, secrets, credentials
+
+Verify all required environment variables, secrets, and credentials are available in the environment where the work will run.
+
+```bash
+# Spot-check the variables the work needs
+echo "${REQUIRED_VAR:?REQUIRED_VAR is not set}"
+```
+
+Missing env vars are silently substituted as empty strings in many setups. The code runs. Nothing works. Check first.
+
+### 5. Existing patterns
+
+Grep for similar past implementations *before* writing new code. If a pattern exists, the implementation should follow it (or explicitly diverge with a reason). Skipping this is how a codebase ends up with three slightly different ways of doing the same thing.
+
+```bash
+# Find prior art
+grep -rn "<RELATED_FUNCTION_OR_TYPE_NAME>" src/
+```
+
+## Why this order
+
+The five checks are ordered by how cheaply they reveal foundation problems:
+
+1. Codegen runs in seconds and tells you whether the type system is honest.
+2. Config placement is a one-line grep that tells you whether the new config will be read.
+3. External service health is a curl that tells you whether the dependency exists.
+4. Env vars are an echo that tells you whether secrets reached this environment.
+5. Existing patterns is a grep that tells you whether you're about to duplicate.
+
+In total, this takes minutes. In total, it prevents the most expensive debugging sessions.
+
+## Common skips and what they cost
+
+**"The codegen probably hasn't drifted."** It has, and the type errors you'll catch later won't be the type errors you'd catch now — they'll be type errors *masking* the real change.
+
+**"I'll wire the config later."** "Later" is the moment of debugging when the feature appears built but does nothing. The fix is one-line; finding which line takes 45 minutes.
+
+**"The API works in the docs."** Docs and reality drift. A 30-second curl against the real endpoint is the difference between a 1-hour integration and an 8-hour integration.
+
+**"The env vars are in the .env file."** Are they in the *running* environment? Containers, sandboxes, and CI often diverge from local. Echo the variable in the actual runtime.
+
+**"I'll find existing patterns as I go."** "As I go" produces parallel implementations. Each is correct in isolation; the next maintainer pays the cost of choosing between them.
+
+## When to skip
+
+A pre-flight check can be skipped only when its failure mode is impossible *for this specific work*. Examples:
+
+- No new config → skip the config placement grep.
+- No external dependency → skip the service health check.
+- A pure refactor that touches no env-var-reading code → skip the env var check.
+
+The skip should be deliberate and justified. The default is to run them.
+
+## Decision
+
+Pre-flight is **fast, boring, and high-value**. It catches the foundation failures that disguise themselves as feature bugs and would otherwise consume the first hours of debugging. The five checks together cost minutes. Skipping them is a false economy.

--- a/skills/forge-implement/references/vertical-phases.md
+++ b/skills/forge-implement/references/vertical-phases.md
@@ -1,0 +1,69 @@
+# Vertical Phases
+
+How to sequence the implementation of an Issue into phases that ship verifiable progress, not layered scaffolding.
+
+## What a phase is
+
+A phase is one implementation chunk inside a single Issue. Each phase touches every layer the chunk needs (data, logic, UI, tests) and ends with a *verification step* — something the agent can run to confirm the phase actually works.
+
+A phase is to an Issue what a vertical slice is to a feature: the same vertical principle, applied at smaller scale. Slicing decides what becomes its own Issue; phasing decides how to sequence work *within* one Issue without pretending it's all one atomic move.
+
+The Pragmatic Programmer calls these "tracer bullets" — each phase is a thin shot through every layer that makes its trajectory visible. Without tracer bullets, the implementer is firing into the dark and finding out at the end whether the bullets were going where intended.
+
+## Why phases instead of "just implement it"
+
+1. **Mid-implementation verification.** Each phase is verifiable in isolation. If phase 3 breaks, you know phases 1 and 2 still work — the bug came in with the most recent slice. Without phases, the only verification is the final run, and bisecting failures takes far longer.
+2. **Commit boundaries that match logical boundaries.** A phase is a natural commit unit. Without phases, commits cluster by file modification time, which is a poor proxy for what actually changed semantically.
+3. **Recovery from interruption.** If a session ends partway through, the agent (or the human) can pick up at the next phase boundary instead of trying to reconstruct "where was I."
+4. **Pressure against horizontal sequencing.** Without phases, the natural drift is to do all the data layer first, then all the API, then all the UI — the opposite of what produces verifiable progress.
+
+## How to identify phases
+
+For each Issue, ask: *what is the smallest end-to-end chunk that proves the next chunk's foundation works?*
+
+Phase 1 is usually the **happy path with no edge cases** — the simplest possible scenario that touches every layer. Phase 2 adds *one* axis of complexity: more cases, more inputs, more error paths. Phase 3 adds another axis. The order is the dependency order — what must work before the next layer of complexity can be added.
+
+Each phase should:
+
+- Touch **all layers** the phase needs (no "just the backend for now")
+- Include a **verification step** that produces a pass/fail signal (a test passing, a curl returning the expected response, a UI flow completing)
+- Take **one PR-sized increment** — if a phase has more than ~5 acceptance items, it's probably two phases
+
+## Common failure modes
+
+**Agents default to horizontal sequencing.** Without explicit guidance, an agent will plan "Phase 1: schema. Phase 2: service layer. Phase 3: API. Phase 4: UI." That's the path of least resistance — each phase is internally coherent and the dependency graph is obvious. It's also the path that produces the worst feedback signal, because nothing user-visible exists until phase 4 and integration bugs all surface at once. Vertical phasing is *deliberately fighting* the agent's default. Expect to rewrite the first attempt at a phase plan.
+
+**Layered phases disguised as vertical.** "Phase 1: data model. Phase 2: API. Phase 3: UI." This is horizontal sequencing renamed. Fix: rewrite each phase so it spans all three layers for *one* scenario.
+
+**Phases without verification.** "Phase 2: implement filter logic." How does the agent know phase 2 is done? Add: "Phase 2 verification: filter test returns expected rows for the seed dataset." If you can't write a verification step, you don't know what "done" means.
+
+**The implicit "wire it up later" phase.** Phases 1–3 build components, phase 4 wires them together, and most of the bugs surface in phase 4. Better: each component phase ends with that component wired into a flow that already exists. Wiring isn't a phase; it's part of every phase.
+
+**Phases too thick to verify.** A phase that touches 12 files and adds 600 lines is probably 2–3 phases pretending to be one. Verification gets weaker as scope expands.
+
+**Decisions hiding in phase text.** "Phase 2: add caching." Cached how? Where? With what invalidation? Decisions should already be captured as durable architectural decisions before phases are listed; if a phase reads as "and figure out X," X is a decision that needs to surface.
+
+**Phase ordering by file rather than by behavior.** Ordering phases as "first the files that already exist, then new files" is a code-organization heuristic, not a behavior heuristic. Phases should order by what *can be verified* given what's been built so far.
+
+## Examples
+
+**Issue**: Add a search bar to the settings page.
+
+Vertical phases:
+
+1. **Search bar UI renders, types into local state, no actual search.** Verifies: typing produces a controlled-input echo. Touches: UI only, but goes end-to-end on the UI side.
+2. **Search filters the visible items in memory using current state.** Verifies: typing "dark" hides items not matching "dark". Touches: UI logic. No backend.
+3. **Search hits a real backend endpoint, debounced.** Verifies: integration test against a seeded dataset returns expected matches. Touches: client + server + tests.
+4. **Search handles the empty-state and error-state UI.** Verifies: zero-results and error-response screens render correctly. Touches: UI edge cases.
+
+Note that no phase ships *only* a layer — every phase has a user-visible verification.
+
+Layered phases (avoid):
+
+1. ~~Backend search endpoint~~ — verifiable only via curl, no UI proves anything.
+2. ~~Search bar UI component~~ — types but doesn't search; meaningless without phase 1.
+3. ~~Wire them together~~ — where all the bugs surface, with no isolated rollback.
+
+## Decision
+
+When laying out phases in Step 2's plan, the question is not *"what are the layers I need to build?"* — it's *"what's the smallest end-to-end increment that proves what comes next?"* The first question yields layered scaffolding; the second yields verifiable phases.


### PR DESCRIPTION
## Summary

Apply the progressive-disclosure pattern (\`forge-reflect\` model, \`forge-create-issue\` pilot) to \`forge-implement\`. Three companions, ~271 lines of philosophy moved from inline to load-on-demand:

- **\`references/vertical-phases.md\` (~75 lines)** — what makes a phase verifiable end-to-end, why agents default to horizontal sequencing and how to fight it, common failure modes (layered phases in disguise, phases without verification, 'wire it up later', decisions hiding in phase text), worked example for a search bar feature. Acknowledges 'tracer bullets' lineage from the Pragmatic Programmer.
- **\`references/pre-flight.md\` (~107 lines)** — the foundation-validation discipline before writing feature code (codegen, config readers, external services, env vars, existing patterns). Frames pre-flight as 'minutes vs hours' insurance against the worst debugging mode.
- **\`references/pattern-audit.md\` (~99 lines)** — what counts as 'the pattern' (judgment beyond literal text matching), how to scope the search, distinguishing missed updates from intentional drift, worked examples for a function rename and an error-shape change.

SKILL.md Step 2 (Plan Approach), Step 4 (Pre-flight checks), and Step 5 (Pattern Consistency Audit) shrink to procedure + companion pointers. Step 5's grep template stays inline (it's procedure, not philosophy).

## Why

Two motivations, same as the create-issue pilot:

1. **Token-cost discipline.** ~271 lines of philosophy now load only when the agent hits the actual decision (not on every \`/forge-implement\` invocation). Implementation skills carry the most embedded philosophy in forge — this is the largest single shift from always-loaded to on-demand.
2. **Crystallizing craft opinion.** The companions articulate things that were implicit before — *why* phasing is vertical (not just what 'vertical' means), *why* pre-flight prevents the most expensive bug class, *what* makes pattern audits a 30-second insurance policy. These are the kind of explanations the user has had to give verbally on past projects.

This is the larger of the two pilots so far (3 companions vs 2 in create-issue). After this, the progressive-disclosure pattern is established across implement, reflect, and create-issue — three of forge's biggest skills. Smaller skills (\`forge-brainstorm\`, \`forge-address-pr-feedback\`, \`forge-setup-project\`) are next candidates as needed; some may stay inline because they don't have enough embedded philosophy to extract.

## Test plan

- [ ] \`/forge-implement\` Step 2 still produces a plan with vertical phases; agent loads \`vertical-phases.md\` if uncertain about phase shape
- [ ] Step 4 pre-flight checks still run before feature code; agent loads \`pre-flight.md\` if uncertain about a check's rationale or scope
- [ ] Step 5 still runs pattern audits when patterns change; agent loads \`pattern-audit.md\` for scope/judgment calls
- [ ] Companions read like opinionated essays (worked examples, common failure modes, judgment frames) rather than skill-section excerpts
- [ ] No cross-skill linking — companions live only in \`forge-implement/references/\` per the self-containment rule