### PR TITLE
docs: articulate smart-zone constraint and add RESHAPE.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ Forge's shared vocabulary. This file defines language used across multiple skill
 
 **Self-containment** — when multiple skills need the same role or reference, the file is duplicated rather than shared via cross-skill path. Skills install independently of each other; cross-skill paths break portability.
 
+**Smart zone** — the portion of an LLM's context window where attention relationships remain manageable and the model performs reliably. Empirically the first ~100k tokens regardless of the advertised context size; performance degrades past this point as accumulated tokens force quadratic attention work. Forge's delegation, fresh-context review, and progressive-disclosure patterns are all responses to this constraint. See [architecture.md — Operating Constraints](docs/architecture.md#operating-constraints) for the full framing.
+
+**Dumb zone** — the portion of context past the smart zone where output quality drops measurably. Visible as missed instructions, forgotten constraints, hallucinated details, and confusion between similarly-named entities. Not a hard threshold; a gradual degradation that becomes pronounced enough to act on.
+
 **Pattern audit** — when a pattern changes in a diff, grep for ALL files using the old pattern and update them. Surfaced both during implementation and during reflection.
 
 **Quality gates** — lint, format, type check, tests. Run before commit, before PR push, and during reflection. A skill is responsible for both running them and reporting results.

--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -1,0 +1,72 @@
+# Forge Reshape
+
+Multi-PR evolution of forge, informed by [Matt Pocock's "Essential Skills for AI Coding" workshop](https://www.youtube.com/watch?v=-QFHIoCo-Ko) and ongoing user collaboration. This document is **temporary** — it lives only during the active reshape and should be removed when the work is complete or paused for >30 days. Track-record lives in git history; intent lives here while the work is in flight.
+
+Workshop transcript (local): `/Users/mgratzer/Library/Mobile Documents/iCloud~md~obsidian/Documents/mgratzer/00 Inbox/Essential Skills for AI Coding from Planning to Production — Matt Pocock (@mattpocockuk ).md`
+
+## Why
+
+Pocock's workshop validated nearly every existing forge primitive (vertical slicing, AFK/HITL split, fresh-context review, sub-agent delegation, blind research) and articulated three framings sharper than forge's: the smart-zone constraint, tracer bullets as the lineage for vertical phases, and push-vs-pull as an architectural distinction. The reshape adopts the *framings*, not the *terminology*; preserves forge's identity (slash command names, three-tier context model, conventional commits, the delegation pattern); and adds craft opinion via progressive disclosure where forge previously held only procedure.
+
+## Principles
+
+- **Stay standards-portable.** Skills target the Agent Skills open standard. Do not accommodate any single runtime in canonical files; runtime-specific quirks live in users' local overrides.
+- **Adopt patterns that articulate forge's implicit choices** (smart zone, tracer bullets, push/pull). Borrow Pocock's *framings*, not his *terms* (no "grill"; we use "shape").
+- **Progressive disclosure for craft opinion.** Each opinionated skill ships SKILL.md (procedure) + `references/<topic>.md` companions (philosophy). Companions load on demand.
+- **Preserve user-facing slash commands.** The `forge-` prefix stays. The single rename allowed in this reshape is `forge-brainstorm` → `forge-shape` because the old name was technically wrong.
+- **Self-containment beats DRY.** Companions and roles duplicate per-skill rather than cross-link, so skills install independently.
+- **No specs-to-code.** Code is the source of truth. PRDs and plans are scaffolding, not destinations.
+- **No premature abstraction.** The issue-tracker provider abstraction is a roadmap goal, not a current skill responsibility. Skills stay GitHub-only until the abstraction earns itself.
+
+## Done
+
+| PR | Title | Outcome |
+|----|-------|---------|
+| [#29](https://github.com/mgratzer/forge/pull/29) | Namespace roles, dedupe checklists, add CONTEXT.md | Roles renamed to `forge-scout`/`forge-reviewer`; `references/review-dimensions.md` extracted; obsolete `model-hint` field removed; `CONTEXT.md` introduced as shared vocabulary |
+| [#30](https://github.com/mgratzer/forge/pull/30) | forge-create-issue progressive-disclosure pilot | Companions: `vertical-slicing.md`, `afk-vs-hitl.md` |
+| [#31](https://github.com/mgratzer/forge/pull/31) | forge-implement progressive-disclosure | Companions: `vertical-phases.md` (with tracer-bullets lineage), `pre-flight.md`, `pattern-audit.md` |
+| [#32](https://github.com/mgratzer/forge/pull/32) | forge-brainstorm → forge-shape rename + convergent methodology | Step 2 batched questioning replaced with one-at-a-time methodology; Step 3 made conditional; Step 4 dropped; companion `shaping-methodology.md` |
+
+## In progress
+
+- **This PR**: smart-zone constraint articulated in `docs/architecture.md` (new "Operating Constraints" section) and `CONTEXT.md` (vocabulary entries); this `RESHAPE.md` document
+
+## Next
+
+Ordered by leverage. Each is its own PR.
+
+1. **forge-tdd skill** — red/green/refactor as the discipline that makes AI honest. SKILL.md is the procedure; companions cover *why TDD makes AI honest* (instrumentation precedes implementation; agents that write tests after the fact fit tests to whatever they built), *what makes a good test in an AI-implemented codebase* (deep-module test boundaries, no per-function mocking), *when TDD is the wrong tool* (UI/visual work, exploratory prototypes). User has explained these verbally on past projects — first crystallization.
+2. **Push vs pull articulation** — add a Design Decisions row in `architecture.md` distinguishing push-loaded (always-in-context: AGENTS.md, system prompts) from pull-loaded (on-demand: skills, companions). Then refactor `forge-reflect` to *push* the rubric and dimensions into reviewer initial context instead of pull, since reliability matters more than token economy in review. Small PR.
+3. **forge-deep-modules skill** — Ousterhout's deep-vs-shallow philosophy as a craft skill with module-shape audit. May absorb Pocock's `improve-codebase-architecture` use case. Companion: the testability argument, the "delegate implementation, design interfaces" insight, audit checklist.
+4. **forge-barrel-imports skill** — opinion crystallization the user has had to explain too many times. Probably small (one SKILL.md + one companion).
+5. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
+6. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice doesn't surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
+
+## Open decisions
+
+- **forge-tdd splits**: one skill or several (e.g., separate `forge-test-design`)? Lean: one skill, multiple companions, see how it feels.
+- **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
+- **forge-deep-modules vs forge-barrel-imports**: separate craft skills, or one `forge-code-shape` with multiple companions? Open question.
+- **What other scattered craft frustrations** belong as forge skills? User mentioned deep modules and barrel imports. Likely more — capture them as they surface.
+
+## Anti-goals
+
+- **No specs-to-code framework.** Forge keeps the code as source of truth; PRDs are scaffolding, not destinations.
+- **No multi-runtime accommodation in canonical files.** Forge runs in Claude Code primarily; Pi, Codex, etc. get standards compliance only. Per-runtime install hacks live outside the repo.
+- **No new top-level abstractions beyond what's earned.** Each abstraction must demonstrate two real use cases before it's promoted to shared infrastructure.
+- **No skill renames except the one already done** (`brainstorm` → `shape`). User muscle memory matters.
+
+## Working norms (during the reshape)
+
+- Each PR is one coherent concern; bundle related changes (vocab + framing), separate unrelated ones (rename and progressive-disclosure pilot were one PR but distinct PRs in retrospect — the lesson stuck).
+- Companion docs aim for ~60–110 lines. Shorter than that suggests the philosophy isn't substantive enough to extract; longer suggests it should be split.
+- The companion structure that has emerged across four files: definition → core principle → why X over Y → mechanics → when to stop / when not to use → common failure modes → decision. Worth treating as a template if it keeps recurring.
+- Claude Code is the assumed primary runtime; the PR description should call out any assumptions that bind to it.
+
+## Removal
+
+Remove this file when:
+- The "Next" list is empty, OR
+- The reshape has been paused with no commits to its branches for >30 days
+
+Per Pocock's anti-doc-rot principle: live planning docs that outlive their usefulness drift from reality and start *misleading* future work. Better to delete and reread the git history.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,25 @@ Role files live inside the skill directory that uses them (e.g., `skills/forge-r
 
 Role names are prefixed with `forge-` (e.g., `forge-scout`, `forge-reviewer`) to keep forge's roles in their own namespace. Subagent runtimes that ship bundled agents under generic names (`scout`, `reviewer`, `worker`) won't shadow forge's roles, and users mixing forge with other skill packs can tell them apart at a glance.
 
+## Operating Constraints
+
+LLMs degrade past approximately 100k tokens regardless of the advertised context window. Attention relationships scale quadratically with token count; the further past 100k a session goes, the worse its instruction-following, recall, and reasoning become. The boundary is not a hard threshold — it is a gradual degradation that becomes pronounced enough to act on.
+
+Practitioners call the workable region the **smart zone** and the degraded region the **dumb zone**. Forge's design choices respond to this constraint:
+
+| Mechanism | How it responds |
+|-----------|-----------------|
+| Sub-agent delegation (`(delegate)` steps) | Move work into fresh context windows when the parent is approaching the dumb zone |
+| Fresh-context review (`forge-reflect`, `forge-ship`) | Reviewer starts in smart zone; implementation memory does not bias review |
+| Progressive disclosure (`references/`) | Load companion philosophy on demand instead of always-loading every skill's full content |
+| Three-tier context model (`AGENTS.md` / `docs/` / specs) | Each tier earns its always-loaded cost; cold tier loads only when needed |
+| Instruction budget (~150–200 instructions per skill body) | Skills stay lean enough to compose without exceeding what frontier LLMs follow consistently |
+| Role files (`roles/*.md`) | Sub-agents start with focused persona context, not the parent's accumulated history |
+
+The smart-zone constraint is approximate, model-dependent, and changing — but treating it as a real boundary tends to produce more reliable workflows than assuming the advertised context size is the working size. When a skill's design feels like it has too many moving parts to fit in one head, that is also approximately when it has too many tokens to fit in the smart zone.
+
+The instruction-budget figure (~150–200 instructions) is a related but distinct constraint covered in [coding-guidelines.md](coding-guidelines.md#instruction-budget) — it concerns how many discrete instructions an LLM follows reliably, separately from how many tokens fit in the smart zone.
+
 ## Design Decisions
 
 | Decision | Choice | Rationale |


### PR DESCRIPTION
## Summary

Two related additions framing forge's design constraints:

### Smart zone in \`docs/architecture.md\` and \`CONTEXT.md\`

New \"Operating Constraints\" section in architecture.md names the ~100k-token attention boundary (the smart zone vs dumb zone) and maps each existing forge mechanism to how it responds:

| Mechanism | How it responds |
|---|---|
| Sub-agent delegation | Move work into fresh context windows |
| Fresh-context review | Reviewer starts in smart zone; implementation memory does not bias review |
| Progressive disclosure | Load companion philosophy on demand |
| Three-tier context model | Each tier earns its always-loaded cost |
| Instruction budget | Skills lean enough to compose without exceeding what LLMs follow |
| Role files | Sub-agents start with focused persona context |

CONTEXT.md gets two new entries (Smart zone, Dumb zone) in the architecture-vocabulary cluster.

### \`RESHAPE.md\` (new, temporary)

Plan document tracking the multi-PR evolution of forge informed by Matt Pocock's workshop. Captures:
- **Why** — what Pocock's transcript validated and what it sharpened
- **Principles** — standards-portable, progressive-disclosure for craft, preserve forge identity, no specs-to-code, no premature abstraction
- **Done** — PRs #29–#32 with outcomes
- **In progress** — this PR
- **Next** — forge-tdd, push vs pull, forge-deep-modules, forge-barrel-imports, issue tracker abstraction
- **Open decisions** — naming and scope questions still in flight
- **Anti-goals** — what the reshape is *not* trying to do
- **Working norms** — companion sizing (~60–110 lines), the structure pattern that's emerged, PR scoping
- **Removal criteria** — delete when Next list is empty or paused >30 days

Lives at repo root for visibility from fresh sessions. Per the anti-doc-rot principle, it gets removed when the work is complete — live planning docs that outlive their usefulness start misleading.

## Why bundle these

Smart-zone is the *durable framing* future work will reference; RESHAPE.md is the *temporary roadmap* that lets work be picked up across sessions. Both are scaffolding for the larger reshape, and both are small additions (no behavior changes). Bundling keeps the PR review surface focused on \"things you need to know to pick up the reshape work.\"

## Test plan

- [ ] \`docs/architecture.md\` Operating Constraints section reads as a coherent framing of why forge does what it does
- [ ] \`CONTEXT.md\` Smart zone / Dumb zone entries are findable when an agent is reading vocabulary
- [ ] \`RESHAPE.md\` is self-contained enough that a fresh Claude Code session reading it can pick up the work without needing the prior conversation
- [ ] PR numbers in the Done table match actual merged PRs (29, 30, 31, 32)
- [ ] No skill behavior changes — this is documentation only