### PR TITLE
docs(implement): add TDD discipline companions

### DIFF
--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -13,6 +13,7 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 - **Stay standards-portable.** Skills target the Agent Skills open standard. Do not accommodate any single runtime in canonical files; runtime-specific quirks live in users' local overrides.
 - **Adopt patterns that articulate forge's implicit choices** (smart zone, tracer bullets, push/pull). Borrow Pocock's *framings*, not his *terms* (no "grill"; we use "shape").
 - **Progressive disclosure for craft opinion.** Each opinionated skill ships SKILL.md (procedure) + `references/<topic>.md` companions (philosophy). Companions load on demand.
+- **Skills are workflow entry points; principles are companions.** A skill earns its slot by being a slash-command moment a user deliberately invokes. A principle that applies *during* another skill's execution belongs as a companion under that skill, not as its own skill. Adding a skill per craft principle inflates the slash-command namespace and works against the smart-zone constraint.
 - **Preserve user-facing slash commands.** The `forge-` prefix stays. The single rename allowed in this reshape is `forge-brainstorm` → `forge-shape` because the old name was technically wrong.
 - **Self-containment beats DRY.** Companions and roles duplicate per-skill rather than cross-link, so skills install independently.
 - **No specs-to-code.** Code is the source of truth. PRDs and plans are scaffolding, not destinations.
@@ -26,28 +27,27 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 | [#30](https://github.com/mgratzer/forge/pull/30) | forge-create-issue progressive-disclosure pilot | Companions: `vertical-slicing.md`, `afk-vs-hitl.md` |
 | [#31](https://github.com/mgratzer/forge/pull/31) | forge-implement progressive-disclosure | Companions: `vertical-phases.md` (with tracer-bullets lineage), `pre-flight.md`, `pattern-audit.md` |
 | [#32](https://github.com/mgratzer/forge/pull/32) | forge-brainstorm → forge-shape rename + convergent methodology | Step 2 batched questioning replaced with one-at-a-time methodology; Step 3 made conditional; Step 4 dropped; companion `shaping-methodology.md` |
+| [#33](https://github.com/mgratzer/forge/pull/33) | docs: articulate smart-zone constraint and add RESHAPE.md | `docs/architecture.md` gained an "Operating Constraints" section; `CONTEXT.md` gained vocabulary entries for smart/dumb zone; this `RESHAPE.md` document was introduced |
 
 ## In progress
 
-- **This PR**: smart-zone constraint articulated in `docs/architecture.md` (new "Operating Constraints" section) and `CONTEXT.md` (vocabulary entries); this `RESHAPE.md` document
+- **This PR**: TDD discipline articulated as companions under `forge-implement` (`tdd-discipline.md`, `good-tests.md`, `when-tdd-is-wrong.md`); forge-implement Step 4 references them; RESHAPE.md gains a *skills-vs-companions* principle. Originally drafted as a `forge-tdd` skill; reframed during shaping — TDD is a discipline applied during implementation, not a workflow entry point.
 
 ## Next
 
 Ordered by leverage. Each is its own PR.
 
-1. **forge-tdd skill** — red/green/refactor as the discipline that makes AI honest. SKILL.md is the procedure; companions cover *why TDD makes AI honest* (instrumentation precedes implementation; agents that write tests after the fact fit tests to whatever they built), *what makes a good test in an AI-implemented codebase* (deep-module test boundaries, no per-function mocking), *when TDD is the wrong tool* (UI/visual work, exploratory prototypes). User has explained these verbally on past projects — first crystallization.
-2. **Push vs pull articulation** — add a Design Decisions row in `architecture.md` distinguishing push-loaded (always-in-context: AGENTS.md, system prompts) from pull-loaded (on-demand: skills, companions). Then refactor `forge-reflect` to *push* the rubric and dimensions into reviewer initial context instead of pull, since reliability matters more than token economy in review. Small PR.
-3. **forge-deep-modules skill** — Ousterhout's deep-vs-shallow philosophy as a craft skill with module-shape audit. May absorb Pocock's `improve-codebase-architecture` use case. Companion: the testability argument, the "delegate implementation, design interfaces" insight, audit checklist.
-4. **forge-barrel-imports skill** — opinion crystallization the user has had to explain too many times. Probably small (one SKILL.md + one companion).
-5. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
-6. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice doesn't surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
+1. **Push vs pull articulation** — add a Design Decisions row in `architecture.md` distinguishing push-loaded (always-in-context: AGENTS.md, system prompts) from pull-loaded (on-demand: skills, companions). Then refactor `forge-reflect` to *push* the rubric and dimensions into reviewer initial context instead of pull, since reliability matters more than token economy in review. Small PR.
+2. **Deep-modules companions for forge-implement (and possibly forge-reflect)** — Ousterhout's deep-vs-shallow philosophy as companion docs invoked from forge-implement (during design choices) and from forge-reflect's Code Reuse & Quality dimension (when reviewing module shape). Companions cover the testability argument, the "delegate implementation, design interfaces" insight, and a module-shape audit checklist. Originally drafted as a `forge-deep-modules` skill; reframed by the *skills-vs-companions* principle.
+3. **Barrel-imports companion for forge-implement** — opinion crystallization the user has had to explain too many times. Likely a single short companion referenced from forge-implement's pre-flight or pattern-audit step. Originally drafted as `forge-barrel-imports` skill; reframed.
+4. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
+5. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
 
 ## Open decisions
 
-- **forge-tdd splits**: one skill or several (e.g., separate `forge-test-design`)? Lean: one skill, multiple companions, see how it feels.
 - **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
-- **forge-deep-modules vs forge-barrel-imports**: separate craft skills, or one `forge-code-shape` with multiple companions? Open question.
-- **What other scattered craft frustrations** belong as forge skills? User mentioned deep modules and barrel imports. Likely more — capture them as they surface.
+- **Deep-modules and barrel-imports placement**: which existing skill do these companions attach to? `forge-implement` is the obvious home for both; `forge-reflect` may also want the deep-modules companion for review-time module-shape audits. Decide per-companion when the work starts.
+- **What other scattered craft frustrations** belong as companions? User mentioned deep modules and barrel imports. Likely more — capture them as they surface, default to companion-under-existing-skill before considering a new skill.
 
 ## Anti-goals
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -102,6 +102,8 @@ Read AGENTS.md first. Follow project conventions strictly.
 - Run tests after each commit, not just at the end
 - When writing tests, verify assertions match actual output immediately
 
+**Test-first when behavior is specifiable.** For testable behavior — business logic, state transitions, parsers, anything with a verifiable claim — follow the red/green/refactor cycle. See [tdd-discipline.md](references/tdd-discipline.md) for the cycle and *why test-first matters more for AI* (write-after rationalization), [good-tests.md](references/good-tests.md) for what to test (deep-module boundaries, no per-function mocking), and [when-tdd-is-wrong.md](references/when-tdd-is-wrong.md) for the cases where TDD is the wrong tool (UI/visual, exploratory prototypes, spikes).
+
 **Commit granularly** after each logical unit of work:
 
 ```bash

--- a/skills/forge-implement/references/good-tests.md
+++ b/skills/forge-implement/references/good-tests.md
@@ -1,0 +1,58 @@
+# Good Tests in AI-Implemented Codebases
+
+What to test, where to test it, and why deep boundaries beat per-function mocks.
+
+## The principle
+
+A test exists to verify that *behavior* works. Behavior is observed at the boundary of a unit — not at every internal function the unit happens to use. A test that mocks every internal call has stopped verifying behavior and started verifying implementation.
+
+In AI-implemented code, this distinction matters more than in human-written code. Humans tend to under-mock; LLMs tend to over-mock. The reason is the same one TDD addresses: an LLM writing tests after the fact mocks whatever the implementation calls, because that is the path of least resistance. The result is a test suite that describes the code's call graph, not its behavior.
+
+## Test at the deep-module boundary
+
+Ousterhout's *deep module* is a unit with a small interface and substantial internal complexity. Tests should target the interface, not the internals. Two reasons:
+
+1. **The interface is the contract; the internals are not.** A refactor that changes internal structure should not break the test suite. If it does, the tests were written against implementation, and the codebase will resist refactoring forever.
+2. **Mocking internals describes the wrong thing.** A test asserting `expect(internalHelper).toHaveBeenCalledWith(...)` says "the code took this path." That is not behavior; it is a trace. The path can change without behavior changing, and behavior can change without the path changing.
+
+The boundary to test at is the *outermost interface that has a meaningful contract*. For a module that exposes one public function and three helpers, the public function is the boundary. For a service with five endpoints, each endpoint is a boundary. For a UI component, the rendered output and emitted events are the boundary.
+
+## Integration over unit, when forced to choose
+
+In AI-implemented code, integration tests catch a class of bugs that unit tests miss: bugs at the *seams* between modules. LLMs are good at producing internally-consistent units that fail to compose. Unit tests pass; integration fails. The bug surfaces at deploy time.
+
+This does not mean unit tests are useless — they remain the right tool for complex logic with many branches. But when a choice has to be made (limited time, limited test surface), prefer the test that exercises real seams to the one that mocks them.
+
+## When to mock
+
+Mock when the dependency:
+
+- Is **non-deterministic** (the system clock, RNG, network calls to external services)
+- Is **expensive** to invoke (a third-party API charging per call)
+- Is **inaccessible** in the test environment (a paid SaaS without a sandbox)
+
+Do *not* mock when the dependency is:
+
+- Internal to the same codebase
+- Cheap and fast (an in-process utility, an in-memory cache)
+- Deterministic and side-effect-free
+
+The tell for over-mocking: the test sets up more mock behavior than the code under test contains real behavior. At that point the mock setup *is* the test, and the test is verifying the mock, not the system.
+
+## Common failure modes
+
+**Mocking everything reachable.** An LLM asked to write tests for a function will mock every call the function makes. This produces tests that pass for code that does not work. Fix: rewrite the test to mock only across non-deterministic or external boundaries; let internal calls run normally.
+
+**Asserting on call traces instead of outputs.** `expect(handler).toHaveBeenCalled()` is rarely the right assertion. The right assertion is "the system produced the expected outcome." Call traces are evidence; outcomes are the contract.
+
+**One test per function.** A codebase with 200 functions does not need 200 tests. It needs tests at the boundaries that have contracts. Per-function tests are the test-suite equivalent of shallow modules — lots of surface area, little depth.
+
+**Tests that fail when names change.** If renaming an internal helper breaks the test suite, the tests are at the wrong level. The interface did not change; the name did. Tests should care about the first and not the second.
+
+**Treating coverage percentage as the goal.** 100% coverage from per-function mocks is worse than 60% coverage from boundary tests. The first verifies a call graph; the second verifies behavior. Coverage is a proxy; behavior verification is the goal.
+
+**Snapshot tests as a default.** Snapshots can lock in a moving target — when the implementation changes, the snapshot is regenerated and the test approves whatever came out. Snapshots are appropriate for *stable* outputs whose drift is meaningful (rendered HTML for a finalized component, serialized error responses); they are not a substitute for asserting on specific behavior.
+
+## Decision
+
+Test at the deep-module boundary, mock only non-deterministic or external dependencies, and prefer integration tests when forced to choose. The test suite that results is smaller, slower-changing, and a better safety net for the refactors AI-implemented code constantly invites.

--- a/skills/forge-implement/references/tdd-discipline.md
+++ b/skills/forge-implement/references/tdd-discipline.md
@@ -1,0 +1,55 @@
+# TDD Discipline
+
+How red/green/refactor keeps AI-implemented code honest.
+
+## The principle
+
+TDD inverts the order of writing: the test exists before the code that satisfies it. The code is then written *for* the test, not the test *for* the code. That inversion is small in mechanics and large in consequence — especially when the code is being written by an LLM.
+
+## Why test-first matters more for AI
+
+An LLM that writes code first and tests second will produce *plausible* tests. They will pass. They will look thorough. They will also be *fitted to whatever was built* rather than fitted to the behavior the work was supposed to implement. The agent is not lying — it is doing the most natural thing: rationalizing tests that match the implementation it just produced.
+
+This is the central failure mode TDD prevents. The test written first commits to a behavior the implementation must serve. The test written second is a description of what the implementation already does, with no independent claim about what it *should* do.
+
+A useful test for whether write-after rationalization is happening: *would these tests catch a bug, or do they just describe the current code?* Tests written after the fact answer the second question whether they meant to or not.
+
+## The cycle
+
+Each iteration is small enough to commit:
+
+1. **Red.** Write a test that captures *one* behavior. Run it. Confirm it fails — and confirm the failure mode is "the behavior is missing," not "the test couldn't load." A `ModuleNotFoundError` is not a real red.
+2. **Green.** Write the *minimum* code that turns the test green. Resist scope expansion. If the test passes with a hardcoded value, the test is too narrow — go back and add another test, then implement properly. If the test passes with general code, you are ready to refactor.
+3. **Refactor.** With the test as a safety net, improve the code's structure: extract helpers, rename, deduplicate. Re-run after every change. Refactoring without the safety net is the move that breaks things; refactoring with it is the move that improves them.
+
+The cycle is short — minutes, not hours. The discipline is in *staying* short. A 90-minute red phase is not TDD; it is a planning session that started with `def test_`.
+
+## Why granularity matters
+
+A red/green/refactor cycle that takes 5 minutes produces a verification signal every 5 minutes. A cycle that takes 90 minutes produces one every 90 minutes. The first is a feedback loop; the second is a project plan.
+
+For AI-implemented code, fast cycles are not optional. Long cycles let the implementation drift from the test's intent — the agent makes decisions that the test never had a chance to push back on, and by the time the test runs, those decisions are baked in. Short cycles keep the test close enough to the implementation that drift does not accumulate.
+
+## Common failure modes
+
+**Writing the test after.** "I'll add tests once it works" is the canonical anti-pattern. The tests that result describe the code; they do not constrain it. The fix is mechanical: write the test before the code, even if you have to delete code you have already written.
+
+**The test that cannot fail.** A test asserting `result is not None` against code that returns a non-None object will pass. A test that always passes provides zero verification. Confirm the red phase actually fails for the *right reason*.
+
+**Over-broad tests.** A single test asserting eight behaviors at once produces a single red→green cycle that does eight things. The cycle is too long; the failure messages are too vague. One behavior per test, even when the behaviors are related.
+
+**Skipping refactor.** "It works, ship it" misses the third of the cycle's three benefits. Refactor is when the safety net pays off. If you never refactor, TDD has gained you correctness but not structure.
+
+**Letting AI write both the test and the code in one shot.** When the same agent produces test and implementation in a single response, the test is no longer independent of the implementation — the agent has already imagined the implementation while writing the test, and the test is shaped by that imagination. Separate the steps: write the test, run it, *then* write the code.
+
+## When the cycle stalls
+
+If the red phase keeps producing tests that pass on the first run, the unit being tested is likely already correct and the test is describing it after the fact — which is not TDD. Either move to a behavior that does not yet work, or accept that this part of the work is not test-driven and switch disciplines.
+
+If the green phase keeps growing past a few minutes, the test is too broad. Split it.
+
+If the refactor phase keeps re-introducing failures, the test is at the wrong boundary — it is constraining implementation details rather than behavior. See [good-tests.md](good-tests.md).
+
+## Decision
+
+TDD's value scales with how much the implementer is asked to trust their own judgment about what is correct. Humans trust their own judgment too much; LLMs rationalize after the fact. Both failure modes are addressed by writing the verifiable claim first. For testable behavior implemented by an LLM, TDD is the discipline that keeps the work honest.

--- a/skills/forge-implement/references/when-tdd-is-wrong.md
+++ b/skills/forge-implement/references/when-tdd-is-wrong.md
@@ -1,0 +1,45 @@
+# When TDD Is the Wrong Tool
+
+TDD is a discipline for *specifiable, verifiable behavior*. Some work is neither.
+
+## The principle
+
+TDD's value comes from a test that captures the intended behavior before the code exists. That requires being able to articulate the behavior as a verifiable claim. When the work does not admit verifiable claims — because the success criterion is judgment-based, exploratory, or visual — TDD's value evaporates and its cost remains.
+
+Forcing TDD onto unsuitable work produces tests that do not actually constrain anything (judgment dressed up as assertions) or block the iteration the work needs (each red phase becomes a planning session for code that is going to be thrown away).
+
+## When to skip TDD
+
+**UI and visual work.** "Does the layout look right" is not a property a test can assert. Snapshot tests can catch unintended changes, but they cannot define what the layout *should* be. Use design review, manual verification, and visual regression tools instead. Add tests for the parts of the UI that *are* behavior — state transitions, event handlers, conditional rendering — but not for the visual surface itself.
+
+**Exploratory prototypes.** A prototype's purpose is to discover whether an idea works at all. Tests written for code that will be rewritten provide negative value: they slow the iteration, they encode decisions that are about to be discarded, and they give false confidence that the prototype is "tested." Time-box the prototype, treat all of it as throwaway, and write tests when the design stabilizes.
+
+**Spikes.** Same logic as prototypes, but shorter. A spike answers a single question — *is this technique viable?* — and gets thrown away regardless of the answer. Tests during a spike measure the wrong thing.
+
+**Migrations of well-tested code.** If the source code already has a strong test suite and the migration preserves behavior, the existing tests *are* the verification. Writing new TDD-style tests for the migrated version duplicates effort and may diverge from the source's behavior in subtle ways. Run the existing tests against the new code; only add tests for behaviors the migration introduces.
+
+**One-shot scripts and operational glue.** A script run once to migrate data, generate a report, or unblock a deployment is verified by inspecting its output. Writing tests for code that runs once and is deleted is theatre.
+
+## When TDD looks wrong but is not
+
+**"The behavior is too complex to test up front."** Usually a sign the behavior should be split into smaller pieces, not that TDD does not apply. The test for the smallest piece is writable; the rest is composition.
+
+**"I do not know what the API will look like yet."** TDD is *how* you find out. Writing the test first forces a decision about the interface before the implementation can lock it in. "I do not know yet" usually means "I have not tried writing a test yet."
+
+**"The library does not support unit testing this."** Sometimes true; usually a tooling gap that gets fixed by writing one helper. Verify the gap is real before invoking it as the reason to skip TDD.
+
+**"It is just configuration."** Configuration with branching logic is code, and the branching logic is testable. Configuration that is purely declarative may not need a test of its own — but the consumer that reads it does.
+
+## Common failure modes
+
+**Forcing TDD where it does not fit.** Writing snapshot tests that lock in the visual quirks of an in-flux design. Writing unit tests against prototype code that gets deleted next week. Both produce tests that constrain nothing useful.
+
+**Abandoning TDD too easily.** "This is exploratory" gets stretched to cover work that has clear behavior the moment you look at it. The honest test: *can I write a test that would fail today and pass after I implement what I am about to implement?* If yes, the work is not exploratory; it is testable behavior.
+
+**Confusing visual work with all UI.** A button's click handler has behavior that TDD applies to. A button's color and padding do not. The same component has both surfaces; treat them differently.
+
+**Treating a spike's output as production code.** A spike that succeeds gets reused, the planned rewrite never happens, and the untested spike code is now load-bearing. If the spike's code is going to ship, that is the moment to start writing tests against it — not later.
+
+## Decision
+
+TDD applies when behavior can be specified as a verifiable claim. When it cannot — UI surface, exploration, throwaway code — use the verification mode appropriate to the work and do not dress it up as testing. The cost of forcing TDD onto unsuitable work is iteration friction; the cost of skipping it on suitable work is rationalized tests. Choose with intent.


### PR DESCRIPTION
## Summary

- Articulates **red/green/refactor as a discipline for AI-implemented code** through three new companions under `forge-implement`, loaded on demand from Step 4. Originally drafted as a `forge-tdd` skill in `RESHAPE.md`; reframed during shaping — TDD is a discipline applied *during* implementation, not a workflow entry point.
- Adds a new **skills-vs-companions principle** to `RESHAPE.md` and applies it to the rest of the "Next" list (deep-modules and barrel-imports also reframed from skills to companions).
- Logs PR #33 as done; `RESHAPE.md` is now consistent with what's actually shipped.

## Changes

**New companions** under `skills/forge-implement/references/`:
- `tdd-discipline.md` — the red/green/refactor cycle and why test-first matters more for AI (write-after rationalization: an LLM that writes tests after the fact rationalizes them to whatever was built)
- `good-tests.md` — deep-module test boundaries; mock only across non-deterministic or external seams; integration over unit when forced to choose
- `when-tdd-is-wrong.md` — UI/visual, exploratory prototypes, spikes, one-shot scripts, migrations of well-tested code; plus *when TDD looks wrong but isn't*

**Skill reference**: `forge-implement` Step 4 gains one short paragraph pointing at all three companions, preserving the SKILL.md instruction budget.

**RESHAPE.md**:
- Move PR #33 to Done table
- Replace "In progress" row with this PR
- Add the *skills-vs-companions* principle to Principles
- Reframe "Next" items #1/#3/#4 from skills to companions
- Resolve the related open decision (`forge-tdd splits`)

## Notes for the reviewer

- **Companion line counts** run slightly under the working norm (45/55/58 vs the ~60–110 target). Held the line on conciseness rather than padding; flag if they read as too thin.
- **No skill renames.** This PR introduces no new skill and renames nothing. Per the reframing, the principle is invoked from existing skills.
- **Claude Code is the assumed runtime**, but no Claude-Code-specific assumptions are encoded — the companions are plain markdown loaded on demand by any Agent Skills runtime.

## Test plan

- [ ] Companions render correctly on GitHub (relative links between `tdd-discipline.md` ↔ `good-tests.md` work)
- [ ] `forge-implement` SKILL.md still reads coherently — the new paragraph integrates rather than disrupts the existing Step 4 flow
- [ ] `RESHAPE.md` "Done" table now lists PRs #29 through #33 in order
- [ ] No broken links from the SKILL.md reference paragraph