### PR TITLE
docs(implement): add deep-modules companion for module-shape design

### DIFF
--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -29,24 +29,24 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 | [#32](https://github.com/mgratzer/forge/pull/32) | forge-brainstorm → forge-shape rename + convergent methodology | Step 2 batched questioning replaced with one-at-a-time methodology; Step 3 made conditional; Step 4 dropped; companion `shaping-methodology.md` |
 | [#33](https://github.com/mgratzer/forge/pull/33) | docs: articulate smart-zone constraint and add RESHAPE.md | `docs/architecture.md` gained an "Operating Constraints" section; `CONTEXT.md` gained vocabulary entries for smart/dumb zone; this `RESHAPE.md` document was introduced |
 | [#34](https://github.com/mgratzer/forge/pull/34) | TDD discipline companions | Companions: `tdd-discipline.md`, `good-tests.md`, `when-tdd-is-wrong.md`; forge-implement Step 4 references them; RESHAPE.md gained *skills-vs-companions* principle |
+| [#36](https://github.com/mgratzer/forge/pull/36) | Push vs pull context loading | Design Decisions row in `architecture.md`; `forge-reflect` and `forge-ship` refactored to push review context into sub-agent initial prompts; `forge-reviewer` role updated to expect pushed context |
 
 ## In progress
 
-- **This PR**: Push vs pull articulation — Design Decisions row in `architecture.md` distinguishing push-loaded from pull-loaded content; `forge-reflect` and `forge-ship` refactored to push rubric, dimensions, and role content into reviewer sub-agent initial prompts; `forge-reviewer` role updated to expect pushed context.
+- **This PR**: Deep-modules companion — `deep-modules.md` under `forge-implement/references/` covering Ousterhout's deep-vs-shallow philosophy, the testability argument, "delegate implementation, design interfaces" insight, and module-shape audit checklist. Referenced from forge-implement Step 2 (durable architectural decisions) and forge-reflect's Code Reuse & Quality dimension (review-time module-shape audit).
 
 ## Next
 
 Ordered by leverage. Each is its own PR.
 
-1. **Deep-modules companions for forge-implement (and possibly forge-reflect)** — Ousterhout's deep-vs-shallow philosophy as companion docs invoked from forge-implement (during design choices) and from forge-reflect's Code Reuse & Quality dimension (when reviewing module shape). Companions cover the testability argument, the "delegate implementation, design interfaces" insight, and a module-shape audit checklist. Originally drafted as a `forge-deep-modules` skill; reframed by the *skills-vs-companions* principle.
-2. **Barrel-imports companion for forge-implement** — opinion crystallization the user has had to explain too many times. Likely a single short companion referenced from forge-implement's pre-flight or pattern-audit step. Originally drafted as `forge-barrel-imports` skill; reframed.
-3. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
-4. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
+1. **Barrel-imports companion for forge-implement** — opinion crystallization the user has had to explain too many times. Likely a single short companion referenced from forge-implement's pre-flight or pattern-audit step. Originally drafted as `forge-barrel-imports` skill; reframed.
+2. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
+3. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
 
 ## Open decisions
 
 - **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
-- **Deep-modules and barrel-imports placement**: which existing skill do these companions attach to? `forge-implement` is the obvious home for both; `forge-reflect` may also want the deep-modules companion for review-time module-shape audits. Decide per-companion when the work starts.
+- **Barrel-imports placement**: which existing skill does this companion attach to? `forge-implement` is the obvious home (pre-flight or pattern-audit step). Decide when the work starts.
 - **What other scattered craft frustrations** belong as companions? User mentioned deep modules and barrel imports. Likely more — capture them as they surface, default to companion-under-existing-skill before considering a new skill.
 
 ## Anti-goals

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -48,7 +48,7 @@ Flag for user input if: vague acceptance criteria, `discovery` label, unanswered
 Identify **durable architectural decisions** — choices that apply across the entire issue:
 - Data model or schema shape
 - API contracts or route structures
-- Key abstractions or module boundaries
+- Key abstractions or module boundaries — see [deep-modules.md](references/deep-modules.md) for how to evaluate module shape, the testability argument, and why interface design matters more than implementation when working with AI
 
 **For complex work** (multiple components, cross-cutting changes, or unclear integration points), delegate codebase research to a sub-agent for unbiased findings:
 

--- a/skills/forge-implement/references/deep-modules.md
+++ b/skills/forge-implement/references/deep-modules.md
@@ -1,0 +1,64 @@
+# Deep Modules
+
+How to design modules whose interfaces are simpler than their implementations — and why this matters more when an AI is writing the code.
+
+## The principle
+
+A *deep module* hides significant complexity behind a simple interface. A *shallow module* exposes an interface nearly as complex as its implementation. The depth of a module is the ratio of complexity it hides to the complexity it exposes. Deeper is better.
+
+This is John Ousterhout's central claim in *A Philosophy of Software Design*: the purpose of a module boundary is to hide complexity. A boundary that hides nothing — a function whose signature tells you everything the body does — is a net cost: the caller must understand the interface *and* the implementation, and the module boundary is just ceremony between the two.
+
+## Why deep modules matter more for AI
+
+When an agent implements code, it generates *plausible* structures. Plausible structures tend to be shallow: one function per concept, each doing one small thing, interfaces that mirror internals. The result compiles, passes lint, and distributes complexity across many modules without actually hiding any of it.
+
+The cost surfaces when the next agent (or human) works on the code. Shallow modules force callers to understand internals to use them correctly. Deep modules let callers stay ignorant of internals — and ignorance is the entire point of abstraction.
+
+An agent designing interfaces should ask: *what can the caller not know?* The more the caller can ignore, the deeper the module.
+
+## Delegate implementation, design interfaces
+
+When working with an AI agent, spend design effort on **interfaces**, not implementations. The agent is good at filling in implementation details once the interface shape is right. It is bad at choosing interface shapes — it defaults to mirroring the internal structure, which produces shallow modules.
+
+In practice:
+- **Define the interface first** — function signature, type shape, API contract — before asking the agent to implement the body
+- **Evaluate the interface in isolation** — can a caller use this without reading the implementation? If not, the interface is too shallow
+- **Let the agent fill in the body** — implementation is where the agent excels; interface design is where it needs guidance
+
+## The testability argument
+
+Deep modules have natural test boundaries. The interface is the contract; tests exercise the contract. When the interface is simple, tests are simple. When the implementation changes behind the interface, tests don't break — because they never depended on the implementation.
+
+Shallow modules invert this. Tests must know about internals to exercise the module meaningfully, which means tests break when internals change. The module boundary provides no stability, so the tests provide no safety net.
+
+If testing a module requires mocking its internals, the module is too shallow — its interface doesn't hide enough to test against.
+
+## Module-shape audit
+
+When designing or reviewing module boundaries, check:
+
+1. **Interface-to-implementation ratio** — is the interface simpler than what it hides? A function with five parameters that calls one library method is shallow. A function with two parameters that orchestrates three subsystems is deep.
+2. **Caller knowledge** — can a caller use this module correctly *without reading the source*? If the caller must know the implementation order, internal state transitions, or which errors to retry, the interface is leaking.
+3. **Change propagation** — if the implementation changes, do callers need to change? Deep modules absorb change; shallow modules propagate it.
+4. **Test shape** — do tests exercise the interface or the internals? Interface-level tests indicate a deep module; tests that mock internals or assert on private state indicate a shallow one.
+5. **Pass-through methods** — methods that add no logic, just forward to another module, are a sign of shallow layering. Each layer should *transform*, not *relay*.
+
+## Common failure modes
+
+**One function per concept.** A module with 15 public functions each doing one small thing is shallow by construction — the caller must compose them, understanding the order and dependencies. Fewer, deeper public functions that compose internally are almost always better.
+
+**Wrapper modules that add nothing.** A class that wraps a library, exposing the same methods with the same signatures, is pure ceremony. Wrappers earn their existence by simplifying the interface — fewer methods, fewer parameters, domain-specific defaults.
+
+**Information leakage between modules.** Two modules that must change together because they share knowledge of the same internal format are a single module split in two. The fix is to consolidate the shared knowledge behind one interface, not to document the coupling.
+
+**Confusing depth with size.** A deep module is not necessarily a large module. A 20-line function can be deep if it hides a non-obvious algorithm behind a two-parameter interface. A 500-line class can be shallow if every method is a pass-through.
+
+## When this doesn't apply
+
+- **Glue code and orchestrators** — top-level wiring that connects deep modules is inherently shallow, and that's fine. Not every layer needs to be deep; the modules it connects do.
+- **Data transfer objects** — DTOs and simple value types have no implementation to hide. Their purpose is to be transparent, not deep.
+- **Early exploration** — during spikes and prototypes, shallow structure is acceptable because the interface hasn't stabilized. Deepen during the refactor pass, not before the shape is known.
+
+## Decision
+
+When designing module boundaries in Step 2's plan, the question is not *"what are the concepts I need to represent?"* — it's *"what complexity can I hide behind a simple interface?"* The first question produces shallow modules that mirror the problem's structure. The second produces deep modules that absorb the problem's complexity, leaving callers with less to know and tests with more stability.

--- a/skills/forge-reflect/references/review-dimensions.md
+++ b/skills/forge-reflect/references/review-dimensions.md
@@ -32,9 +32,10 @@ Four quality dimensions for parallel review. Each reviewer agent receives one di
 1. **Redundant implementations** — search the codebase for existing helpers, utilities, or shared modules that already solve the same problem before accepting new code
 2. **Extraction opportunities** — repeated logic across the diff, or inline code that reimplements what a shared module already provides (string manipulation, path handling, type guards, environment checks)
 3. **Structural bloat** — functions growing beyond a screenful, parameter lists growing instead of restructuring, state that duplicates what's already tracked elsewhere
-4. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
-5. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
-6. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
+4. **Module shape** — shallow modules whose interfaces mirror their internals, pass-through methods that relay without transforming, wrapper classes that add no simplification. See [deep-modules.md](../../forge-implement/references/deep-modules.md) for the audit checklist
+5. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
+6. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
+7. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
 
 ## Agent 4 — Efficiency, Tests & Docs
 


### PR DESCRIPTION
## Summary

- Added `skills/forge-implement/references/deep-modules.md` (~78 lines) — Ousterhout's deep-vs-shallow module philosophy as a progressive-disclosure companion
- Referenced from forge-implement Step 2 (durable architectural decisions → "Key abstractions or module boundaries")
- Added "Module shape" item (#4) to forge-reflect's Code Reuse & Quality review dimension with link to the companion
- Updated RESHAPE.md: push-vs-pull (#36) moved to Done table, deep-modules set as In progress, resolved the placement open decision

## Motivation

Originally drafted as a standalone `forge-deep-modules` skill; reframed by the skills-vs-companions principle — deep modules is a design discipline applied during implementation, not a workflow entry point. The companion covers three insights specific to AI-assisted development: agents default to shallow interfaces, interface design is the highest-leverage human contribution, and deep modules produce natural test boundaries.

## Test plan

- [ ] Invoke `forge-implement` and verify the deep-modules reference appears in Step 2 when planning module boundaries
- [ ] Invoke `forge-reflect` and verify Agent 3 (Code Reuse & Quality) includes the new "Module shape" checklist item
- [ ] Verify the cross-link from `review-dimensions.md` to `deep-modules.md` resolves correctly
- [ ] Confirm companion follows the established template (definition → principle → mechanics → failure modes → decision)
- [ ] Confirm line count is within 60-110 target range