### PR TITLE
docs(implement): add verify-before-assume companion for API hallucination prevention

### DIFF
--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -30,10 +30,11 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 | [#33](https://github.com/mgratzer/forge/pull/33) | docs: articulate smart-zone constraint and add RESHAPE.md | `docs/architecture.md` gained an "Operating Constraints" section; `CONTEXT.md` gained vocabulary entries for smart/dumb zone; this `RESHAPE.md` document was introduced |
 | [#34](https://github.com/mgratzer/forge/pull/34) | TDD discipline companions | Companions: `tdd-discipline.md`, `good-tests.md`, `when-tdd-is-wrong.md`; forge-implement Step 4 references them; RESHAPE.md gained *skills-vs-companions* principle |
 | [#36](https://github.com/mgratzer/forge/pull/36) | Push vs pull context loading | Design Decisions row in `architecture.md`; `forge-reflect` and `forge-ship` refactored to push review context into sub-agent initial prompts; `forge-reviewer` role updated to expect pushed context |
+| [#37](https://github.com/mgratzer/forge/pull/37) | Deep-modules companion | Companion: `deep-modules.md` covering Ousterhout's deep-vs-shallow philosophy, testability argument, "delegate implementation, design interfaces" insight, module-shape audit checklist; referenced from forge-implement Step 2 and forge-reflect's Code Reuse & Quality dimension |
 
 ## In progress
 
-- **This PR**: Deep-modules companion — `deep-modules.md` under `forge-implement/references/` covering Ousterhout's deep-vs-shallow philosophy, the testability argument, "delegate implementation, design interfaces" insight, and module-shape audit checklist. Referenced from forge-implement Step 2 (durable architectural decisions) and forge-reflect's Code Reuse & Quality dimension (review-time module-shape audit).
+- **This PR**: Verify-before-assume companion — `verify-before-assume.md` under `forge-implement/references/` covering why agents hallucinate APIs (version drift, interpolation, flag invention), the verification discipline (grep codebase, read type definitions, check `--help`), and when verification isn't needed (stdlib, already used in codebase, already verified this session). Referenced from forge-implement Step 4 (as you code). Prompted by recurring user experience of agents inventing API methods and CLI flags that don't exist.
 
 ## Next
 
@@ -47,7 +48,7 @@ Ordered by leverage. Each is its own PR.
 
 - **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
 - **Barrel-imports placement**: which existing skill does this companion attach to? `forge-implement` is the obvious home (pre-flight or pattern-audit step). Decide when the work starts.
-- **What other scattered craft frustrations** belong as companions? User mentioned deep modules and barrel imports. Likely more — capture them as they surface, default to companion-under-existing-skill before considering a new skill.
+- **What other scattered craft frustrations** belong as companions? User mentioned deep modules, barrel imports, and API hallucination. The first and third are now addressed as companions. Capture more as they surface, default to companion-under-existing-skill before considering a new skill.
 
 ## Anti-goals
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ forge/
 │   ├── forge-create-issue/SKILL.md        # Step 1: Plan and create GitHub issues
 │   ├── forge-implement/
 │   │   ├── SKILL.md                       # Step 2: Implement from issue, plan, or description
+│   │   ├── references/                    # Progressive disclosure: implementation craft companions
 │   │   └── roles/forge-scout.md           # Blind codebase research persona
 │   ├── forge-reflect/
 │   │   ├── SKILL.md                       # Step 3: Self-review changes (PR, branch, or uncommitted)

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -99,6 +99,7 @@ Read AGENTS.md first. Follow project conventions strictly.
 - Check for duplication — extract shared logic
 - Keep functions focused — split if growing too large
 - Look for existing patterns before writing new code
+- Verify unfamiliar APIs before using them — grep the codebase, read type definitions, or check `--help`. See [verify-before-assume.md](references/verify-before-assume.md) for why agents hallucinate APIs, the verification discipline, and when verification isn't needed
 - Run tests after each commit, not just at the end
 - When writing tests, verify assertions match actual output immediately
 

--- a/skills/forge-implement/references/verify-before-assume.md
+++ b/skills/forge-implement/references/verify-before-assume.md
@@ -45,7 +45,11 @@ For **CLI tools**: use the tool's own help.
 gh issue create --help
 ```
 
-For **HTTP APIs**: make a lightweight probe before writing the integration (pre-flight check #3 already covers service reachability — this extends it to endpoint shape).
+For **HTTP APIs**: probe the actual endpoint before writing the integration.
+
+```bash
+curl -s "$API_BASE/endpoint" | head -c 500
+```
 
 ### 3. Check the version
 
@@ -53,7 +57,7 @@ When the project pins a specific version of a dependency, verify the API exists 
 
 ```bash
 # Check what version is installed
-cat package.json | grep "<package>"
+grep "<package>" package.json
 ```
 
 ## When verification isn't needed

--- a/skills/forge-implement/references/verify-before-assume.md
+++ b/skills/forge-implement/references/verify-before-assume.md
@@ -1,0 +1,78 @@
+# Verify Before Assume
+
+When using an API you haven't called in this session, verify it exists before writing code against it. This is the single most effective defense against the agent failure mode where code looks correct but calls things that don't exist.
+
+## The principle
+
+An agent's training data is a snapshot. Libraries release new versions, CLI tools add and remove flags, HTTP endpoints change shape, internal functions get renamed. When an agent writes code that calls an API, it is *guessing* based on what was true at training time — not checking what is true now.
+
+The guess is usually right. When it's wrong, the failure is uniquely expensive: the code compiles (or at least parses), the structure looks plausible, and the developer debugging it has no reason to suspect the *method itself* doesn't exist. They spend time debugging the call, the arguments, the context — everything except the one thing that's wrong.
+
+## Why agents hallucinate APIs
+
+Agents produce *plausible completions*. An API call is plausible when it follows the naming conventions of the library, takes the right number of arguments, and fits the surrounding code. Plausibility is not correctness. A method named `createWithOptions()` is plausible for almost any SDK — that doesn't mean it exists.
+
+Three common triggers:
+
+1. **Version drift.** The agent's training data has v2 of a library; the project uses v3 (or v1). Methods were added, removed, or renamed between versions.
+2. **Interpolation.** The agent has seen similar APIs in similar libraries and interpolates a method that *should* exist based on the pattern — but doesn't.
+3. **Flag invention.** CLI tools are especially prone. The agent has seen `--parent`, `--recursive`, `--dry-run` on various commands and confidently applies them to commands that don't support them.
+
+## The verification discipline
+
+Before using an unfamiliar API — any method, flag, endpoint, or type you haven't already seen used in this codebase or verified in this session:
+
+### 1. Check the codebase first
+
+```bash
+grep -rn "<method-or-flag>" src/
+```
+
+If the codebase already uses this API, follow the existing usage pattern. Existing usage is the strongest evidence that the API exists and works in this project's version.
+
+### 2. Check the source or docs
+
+For **libraries**: read the actual type definitions or source.
+
+```bash
+# For Node.js / TypeScript — check installed type definitions
+grep -rn "<method-name>" node_modules/<package>/
+```
+
+For **CLI tools**: use the tool's own help.
+
+```bash
+gh issue create --help
+```
+
+For **HTTP APIs**: make a lightweight probe before writing the integration (pre-flight check #3 already covers service reachability — this extends it to endpoint shape).
+
+### 3. Check the version
+
+When the project pins a specific version of a dependency, verify the API exists *at that version*, not just in the latest release.
+
+```bash
+# Check what version is installed
+cat package.json | grep "<package>"
+```
+
+## When verification isn't needed
+
+- **Standard library.** Language builtins are stable enough that training-data knowledge is reliable. `Array.map`, `os.path.join`, `fmt.Sprintf` — these don't need verification.
+- **Already used in this codebase.** If you've seen `fetchUser()` called in three files, it exists. Follow the existing call pattern.
+- **Already verified this session.** One check per API per session is enough. Don't re-verify on every use.
+- **The project has type checking.** A type checker will catch nonexistent methods on typed interfaces. Verification still helps for untyped code, dynamic languages, CLI calls, and HTTP endpoints — anything the type checker can't reach.
+
+## Common failure modes
+
+**Confident usage of a plausible flag.** The agent writes `gh issue create --parent 42` with full confidence. The flag doesn't exist in the installed `gh` version. The command fails with an unhelpful error, and the developer spends time debugging arguments instead of questioning the flag's existence.
+
+**Version-shifted method names.** A library renamed `client.query()` to `client.execute()` in v4. The agent writes `client.query()` because it has more training examples of v3. The code fails at runtime with "method not found" — a confusing error when the method *did* exist in a different version.
+
+**Interpolated convenience methods.** The agent assumes a library has `findOrCreate()` because similar ORMs do. The actual library only has `find()` and `create()` separately. The agent writes clean, readable code that calls a function that was never implemented.
+
+**Skipping verification because "I know this library."** The agent's training data is not current knowledge. "Knowing" a library means having seen examples of it — possibly from a version that no longer matches the project. Verification takes seconds; debugging hallucinated APIs takes hours.
+
+## Decision
+
+The bar is low: **one grep, one `--help`, or one type-definition read** before using an API you haven't seen in the current codebase. The cost is seconds. The cost of skipping is a debugging session where the developer trusts the code and hunts for bugs that aren't there — because the real bug is that the API the agent called doesn't exist.


### PR DESCRIPTION
## Summary

- New companion `verify-before-assume.md` under `forge-implement/references/` — codifies the discipline of verifying unfamiliar APIs before using them
- Covers three triggers for API hallucination (version drift, interpolation, flag invention), the verification discipline (grep codebase → read type definitions → check `--help`), and when verification isn't needed (stdlib, already used in codebase, already verified this session)
- Referenced from forge-implement Step 4 "As you code" section
- RESHAPE.md updated: deep-modules (#37) moved to Done, this PR tracked as in-progress, open-decisions updated to note API hallucination is now addressed

## Motivation

Recurring user experience of agents inventing API methods and CLI flags that don't exist (e.g., `gh issue create --parent`). The code looks correct, compiles or parses, but calls things that were never implemented — leading to expensive debugging sessions where the developer trusts the code and hunts for bugs that aren't there.

## Test plan

- [ ] Companion follows established structure (definition → principle → mechanics → when-not-to → failure modes → decision)
- [ ] Line count within 60–110 range (78 lines)
- [ ] forge-implement Step 4 reference renders correctly and links to the companion
- [ ] RESHAPE.md accurately reflects current state (deep-modules done, this PR in-progress)
- [ ] No cross-skill references broken