### PR TITLE
docs(implement): add barrel-imports companion for import structure discipline

### DIFF
--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -31,24 +31,23 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 | [#34](https://github.com/mgratzer/forge/pull/34) | TDD discipline companions | Companions: `tdd-discipline.md`, `good-tests.md`, `when-tdd-is-wrong.md`; forge-implement Step 4 references them; RESHAPE.md gained *skills-vs-companions* principle |
 | [#36](https://github.com/mgratzer/forge/pull/36) | Push vs pull context loading | Design Decisions row in `architecture.md`; `forge-reflect` and `forge-ship` refactored to push review context into sub-agent initial prompts; `forge-reviewer` role updated to expect pushed context |
 | [#37](https://github.com/mgratzer/forge/pull/37) | Deep-modules companion | Companion: `deep-modules.md` covering Ousterhout's deep-vs-shallow philosophy, testability argument, "delegate implementation, design interfaces" insight, module-shape audit checklist; referenced from forge-implement Step 2 and forge-reflect's Code Reuse & Quality dimension |
+| [#38](https://github.com/mgratzer/forge/pull/38) | Verify-before-assume companion | Companion: `verify-before-assume.md` covering API hallucination (version drift, interpolation, flag invention), the verification discipline, and when verification isn't needed; referenced from forge-implement Step 4 |
 
 ## In progress
 
-- **This PR**: Verify-before-assume companion — `verify-before-assume.md` under `forge-implement/references/` covering why agents hallucinate APIs (version drift, interpolation, flag invention), the verification discipline (grep codebase, read type definitions, check `--help`), and when verification isn't needed (stdlib, already used in codebase, already verified this session). Referenced from forge-implement Step 4 (as you code). Prompted by recurring user experience of agents inventing API methods and CLI flags that don't exist.
+- **This PR**: Barrel-imports companion — `barrel-imports.md` under `forge-implement/references/` covering why agents default to barrel files, the real costs (circular deps, tree-shaking, obscured origin, merge conflicts), when barrels earn their cost (published API boundary, existing convention, framework requirement), and the discipline (check before creating). Referenced from forge-implement Step 4 ("as you code" — existing patterns bullet) and forge-reflect's Code Reuse & Quality dimension (new item 5). Resolves open decision on barrel-imports placement.
 
 ## Next
 
 Ordered by leverage. Each is its own PR.
 
-1. **Barrel-imports companion for forge-implement** — opinion crystallization the user has had to explain too many times. Likely a single short companion referenced from forge-implement's pre-flight or pattern-audit step. Originally drafted as `forge-barrel-imports` skill; reframed.
-2. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
-3. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
+1. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
+2. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
 
 ## Open decisions
 
 - **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
-- **Barrel-imports placement**: which existing skill does this companion attach to? `forge-implement` is the obvious home (pre-flight or pattern-audit step). Decide when the work starts.
-- **What other scattered craft frustrations** belong as companions? User mentioned deep modules, barrel imports, and API hallucination. The first and third are now addressed as companions. Capture more as they surface, default to companion-under-existing-skill before considering a new skill.
+- **What other scattered craft frustrations** belong as companions? User mentioned deep modules, barrel imports, and API hallucination. All three are now addressed as companions. Capture more as they surface, default to companion-under-existing-skill before considering a new skill.
 
 ## Anti-goals
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -98,7 +98,7 @@ Read AGENTS.md first. Follow project conventions strictly.
 - Follow project lint/format/type conventions
 - Check for duplication — extract shared logic
 - Keep functions focused — split if growing too large
-- Look for existing patterns before writing new code
+- Look for existing patterns before writing new code — in particular, follow the project's existing import style and do not introduce barrel files (index re-exports) unless the project already uses them. See [barrel-imports.md](references/barrel-imports.md) for why agents default to barrel files, the real costs, and the few cases where they earn their place
 - Verify unfamiliar APIs before using them — grep the codebase, read type definitions, or check `--help`. See [verify-before-assume.md](references/verify-before-assume.md) for why agents hallucinate APIs, the verification discipline, and when verification isn't needed
 - Run tests after each commit, not just at the end
 - When writing tests, verify assertions match actual output immediately

--- a/skills/forge-implement/references/barrel-imports.md
+++ b/skills/forge-implement/references/barrel-imports.md
@@ -4,7 +4,14 @@ Why agents create barrel files, when they cause real harm, and the few cases whe
 
 ## The principle
 
-A *barrel file* is an `index.ts` (or `index.js`, `__init__.py`, `mod.rs`) that re-exports symbols from other modules in the same directory. Its purpose is to let callers import from the directory path instead of the specific file:
+A *barrel file* re-exports symbols from other modules in the same directory so callers can import from the directory path instead of the specific file. The name and mechanism vary by ecosystem:
+
+| Ecosystem | Barrel file | Effect |
+|-----------|------------|--------|
+| TypeScript / JavaScript | `index.ts` / `index.js` | `import { X } from './dir'` resolves to the index |
+| Python | `__init__.py` | `from package import X` runs the init and re-exports |
+| Rust | `mod.rs` | `use crate::module::X` routes through the module root |
+| Go | no barrel convention | packages are already directory-scoped |
 
 ```ts
 // components/index.ts — the barrel
@@ -13,8 +20,18 @@ export { Input } from './Input';
 export { Modal } from './Modal';
 
 // caller
-import { Button } from './components';      // via barrel
+import { Button } from './components';        // via barrel
 import { Button } from './components/Button'; // direct
+```
+
+```python
+# utils/__init__.py — the barrel
+from .strings import slugify
+from .dates import parse_date
+
+# caller
+from utils import slugify          # via barrel
+from utils.strings import slugify  # direct
 ```
 
 The barrel adds a layer of indirection. That layer has a cost. The question is whether the cost is justified.
@@ -23,15 +40,15 @@ The barrel adds a layer of indirection. That layer has a cost. The question is w
 
 Agents produce *plausible structure*. Barrel files look like good engineering: they shorten import paths, centralize a directory's public API, and mirror patterns the agent has seen in popular open-source libraries. The agent creates them reflexively — the same way it creates wrapper classes and one-function-per-concept modules — because the *shape* looks clean, not because the *trade-off* was evaluated.
 
-The result is a codebase where every directory has an index file that re-exports everything in it. No caller asked for this. No bundler benefits from it. The barrel exists because the agent thought it should.
+The result is a codebase where every directory has an index file that re-exports everything in it. No caller asked for this. The barrel exists because the agent thought it should.
 
 ## The costs
 
 **Circular dependency risk.** Barrel files pull an entire directory's exports into a single module. When two directories barrel-import from each other — or when a file within the directory imports from its own barrel — the result is a circular dependency that may fail silently (undefined at import time) or noisily (runtime crash), depending on the module system.
 
-**Tree-shaking breakage.** Bundlers that don't analyze re-exports deeply treat a barrel import as "this caller needs everything in this directory." The unused exports survive into the bundle. In large codebases this adds meaningful dead code to production builds.
+**Unnecessary loading.** In JS/TS, bundlers that don't analyze re-exports deeply treat a barrel import as "this caller needs everything in this directory" — unused exports survive into the production bundle. In Python, importing from a package runs `__init__.py` at import time, executing all re-exports and their transitive dependencies even when the caller needs only one symbol. The mechanism differs; the result is the same: the caller pays for modules it never uses.
 
-**Obscured origin.** `import { fetchUser } from '@/lib'` tells the reader nothing about where `fetchUser` is defined. They must open the barrel, find the re-export, then navigate to the source file. Direct imports — `import { fetchUser } from '@/lib/api/users'` — are self-documenting.
+**Obscured origin.** `import { fetchUser } from '@/lib'` or `from utils import slugify` tells the reader nothing about where the symbol is defined. They must open the barrel, find the re-export, then navigate to the source file. Direct imports are self-documenting.
 
 **Merge conflict surface.** Every new export in a directory means a line added to the barrel. When multiple contributors add exports to the same directory in parallel, the barrel becomes a merge conflict magnet — a file that exists only for organizational ceremony, not for functionality, yet blocks merges.
 
@@ -43,7 +60,7 @@ The result is a codebase where every directory has an index file that re-exports
 
 **The project already uses them consistently.** If the codebase has an established convention of barrel files, follow it. Mixing barrel and direct imports is worse than either style alone. The pattern audit applies here: match what exists.
 
-**Framework convention.** Some frameworks (e.g., Angular modules, certain Next.js patterns) expect or generate barrel files. Fighting the framework's convention creates more friction than the barrel does.
+**Framework or ecosystem convention.** Some frameworks and ecosystems expect barrel files — Angular modules, Next.js route groups, Python packages with documented `__init__.py` APIs, Rust crate public modules. Fighting the convention creates more friction than the barrel does.
 
 ## The discipline
 
@@ -53,15 +70,15 @@ Before creating a barrel file, check:
 2. **Is this a public API boundary?** If the directory is consumed by external callers (other packages, published library users), a barrel is justified.
 3. **Is this an internal directory?** If callers are within the same project, direct imports are almost always better. The barrel adds indirection without adding value.
 
-When in doubt, use direct imports. They are always correct, never create circular dependencies, never break tree-shaking, and never obscure where a symbol is defined.
+When in doubt, use direct imports. They are always correct, never create circular dependencies, never cause unnecessary loading, and never obscure where a symbol is defined.
 
 ## Common failure modes
 
-**Barrel-per-directory by default.** The agent creates an `index.ts` in every new directory as a matter of course. No caller requested it. No convention requires it. The barrel exists because the agent's training data associates directories with index files.
+**Barrel-per-directory by default.** The agent creates an index file in every new directory as a matter of course — `index.ts`, `__init__.py`, or the ecosystem equivalent. No caller requested it. No convention requires it. The barrel exists because the agent's training data associates directories with index files.
 
 **Re-exporting everything.** A barrel that exports every symbol in the directory is not curating an API — it's adding an indirection layer with no filtering. Barrels earn their cost by *hiding* internals, not by *mirroring* them.
 
-**Importing from own barrel.** A file within a directory imports from its own `index.ts` instead of from sibling files directly. This is the shortest path to a circular dependency and a sign the barrel is being used for convenience rather than architecture.
+**Importing from own barrel.** A file within a directory imports from its own index file instead of from sibling files directly. This is the shortest path to a circular dependency and a sign the barrel is being used for convenience rather than architecture.
 
 **Adding barrels during refactoring.** An agent tasked with "clean up imports" introduces barrel files as part of the cleanup. The cleanup adds a new dependency structure the codebase didn't have, creating risk where none existed.
 

--- a/skills/forge-implement/references/barrel-imports.md
+++ b/skills/forge-implement/references/barrel-imports.md
@@ -1,0 +1,70 @@
+# Barrel Imports
+
+Why agents create barrel files, when they cause real harm, and the few cases where they earn their cost.
+
+## The principle
+
+A *barrel file* is an `index.ts` (or `index.js`, `__init__.py`, `mod.rs`) that re-exports symbols from other modules in the same directory. Its purpose is to let callers import from the directory path instead of the specific file:
+
+```ts
+// components/index.ts — the barrel
+export { Button } from './Button';
+export { Input } from './Input';
+export { Modal } from './Modal';
+
+// caller
+import { Button } from './components';      // via barrel
+import { Button } from './components/Button'; // direct
+```
+
+The barrel adds a layer of indirection. That layer has a cost. The question is whether the cost is justified.
+
+## Why agents create barrel files
+
+Agents produce *plausible structure*. Barrel files look like good engineering: they shorten import paths, centralize a directory's public API, and mirror patterns the agent has seen in popular open-source libraries. The agent creates them reflexively — the same way it creates wrapper classes and one-function-per-concept modules — because the *shape* looks clean, not because the *trade-off* was evaluated.
+
+The result is a codebase where every directory has an index file that re-exports everything in it. No caller asked for this. No bundler benefits from it. The barrel exists because the agent thought it should.
+
+## The costs
+
+**Circular dependency risk.** Barrel files pull an entire directory's exports into a single module. When two directories barrel-import from each other — or when a file within the directory imports from its own barrel — the result is a circular dependency that may fail silently (undefined at import time) or noisily (runtime crash), depending on the module system.
+
+**Tree-shaking breakage.** Bundlers that don't analyze re-exports deeply treat a barrel import as "this caller needs everything in this directory." The unused exports survive into the bundle. In large codebases this adds meaningful dead code to production builds.
+
+**Obscured origin.** `import { fetchUser } from '@/lib'` tells the reader nothing about where `fetchUser` is defined. They must open the barrel, find the re-export, then navigate to the source file. Direct imports — `import { fetchUser } from '@/lib/api/users'` — are self-documenting.
+
+**Merge conflict surface.** Every new export in a directory means a line added to the barrel. When multiple contributors add exports to the same directory in parallel, the barrel becomes a merge conflict magnet — a file that exists only for organizational ceremony, not for functionality, yet blocks merges.
+
+**IDE and tooling friction.** Auto-import features often resolve to the barrel path instead of the source path, creating inconsistent import styles. "Go to definition" lands on the re-export line, requiring a second jump. These are small frictions that compound across a codebase.
+
+## When barrels earn their cost
+
+**Published package boundary.** A library consumed by external callers needs a stable, curated public API. The barrel *is* the API surface — it declares what's public and what's internal. This is the original use case and the one where the trade-off is clearly positive.
+
+**The project already uses them consistently.** If the codebase has an established convention of barrel files, follow it. Mixing barrel and direct imports is worse than either style alone. The pattern audit applies here: match what exists.
+
+**Framework convention.** Some frameworks (e.g., Angular modules, certain Next.js patterns) expect or generate barrel files. Fighting the framework's convention creates more friction than the barrel does.
+
+## The discipline
+
+Before creating a barrel file, check:
+
+1. **Does this directory already have one?** If yes, follow the existing pattern — add the export, don't fight the convention.
+2. **Is this a public API boundary?** If the directory is consumed by external callers (other packages, published library users), a barrel is justified.
+3. **Is this an internal directory?** If callers are within the same project, direct imports are almost always better. The barrel adds indirection without adding value.
+
+When in doubt, use direct imports. They are always correct, never create circular dependencies, never break tree-shaking, and never obscure where a symbol is defined.
+
+## Common failure modes
+
+**Barrel-per-directory by default.** The agent creates an `index.ts` in every new directory as a matter of course. No caller requested it. No convention requires it. The barrel exists because the agent's training data associates directories with index files.
+
+**Re-exporting everything.** A barrel that exports every symbol in the directory is not curating an API — it's adding an indirection layer with no filtering. Barrels earn their cost by *hiding* internals, not by *mirroring* them.
+
+**Importing from own barrel.** A file within a directory imports from its own `index.ts` instead of from sibling files directly. This is the shortest path to a circular dependency and a sign the barrel is being used for convenience rather than architecture.
+
+**Adding barrels during refactoring.** An agent tasked with "clean up imports" introduces barrel files as part of the cleanup. The cleanup adds a new dependency structure the codebase didn't have, creating risk where none existed.
+
+## Decision
+
+The default is **no barrel file**. Direct imports are explicit, safe, and tooling-friendly. A barrel earns its place only at a published API boundary or where the project already uses them by convention. When an agent reaches for an index file, the question is not "would this look cleaner?" — it's "does this directory need a curated public API that hides internals from external consumers?" If the answer is no, skip the barrel.

--- a/skills/forge-reflect/references/review-dimensions.md
+++ b/skills/forge-reflect/references/review-dimensions.md
@@ -33,9 +33,10 @@ Four quality dimensions for parallel review. Each reviewer agent receives one di
 2. **Extraction opportunities** — repeated logic across the diff, or inline code that reimplements what a shared module already provides (string manipulation, path handling, type guards, environment checks)
 3. **Structural bloat** — functions growing beyond a screenful, parameter lists growing instead of restructuring, state that duplicates what's already tracked elsewhere
 4. **Module shape** — shallow modules whose interfaces mirror their internals, pass-through methods that relay without transforming, wrapper classes that add no simplification. See [deep-modules.md](../../forge-implement/references/deep-modules.md) for the audit checklist
-5. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
-6. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
-7. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
+5. **Unnecessary indirection** — barrel files (index re-exports) introduced without a published-API boundary or existing project convention. See [barrel-imports.md](../../forge-implement/references/barrel-imports.md) for the costs and when barrels earn their place
+6. **Dead weight** — unused imports, unreachable branches, or variables introduced but never read
+7. **Misleading names** — only when a name will actively confuse the next reader, not style preferences
+8. **Comment noise** — comments that narrate what the code does or reference the ticket; keep only non-obvious "why" (hidden constraints, workarounds, subtle invariants)
 
 ## Agent 4 — Efficiency, Tests & Docs
 


### PR DESCRIPTION
## Summary

- Add `barrel-imports.md` companion under `forge-implement/references/` covering why agents default to barrel files, the real costs (circular deps, tree-shaking breakage, obscured origin, merge conflict surface, IDE friction), when barrels earn their cost (published API boundary, existing convention, framework requirement), and the discipline (check before creating)
- Reference from forge-implement Step 4 "As you code" — extends the "look for existing patterns" bullet with barrel-file guidance
- Reference from forge-reflect's Code Reuse & Quality dimension as new item 5 ("Unnecessary indirection"), following the cross-reference precedent set by `deep-modules.md`
- Update RESHAPE.md: move barrel-imports from Next to In Progress, log PR #38 (verify-before-assume) as Done, resolve barrel-imports placement open decision, update "all three addressed" in open decisions

Placement decision: attached to forge-implement Step 4 ("as you code") rather than pre-flight or pattern-audit. Barrel imports are an implementation choice agents make while writing code — not a foundation check (pre-flight) or a post-hoc consistency sweep (pattern-audit).

## Test plan

- [ ] Read `barrel-imports.md` — follows companion template (definition → principle → why agents do it → costs → when appropriate → discipline → failure modes → decision)
- [ ] Verify line count is within 60–110 range (70 lines)
- [ ] Verify forge-implement Step 4 reference links correctly
- [ ] Verify forge-reflect review-dimensions item 5 cross-reference path resolves
- [ ] Verify RESHAPE.md accurately reflects current state
- [ ] Pattern audit: grep `barrel` across repo — all references consistent