### PR TITLE
refactor(skills): issue tracker provider abstraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Forge
 
-Forge is a collection of agent skills that define a structured, GitHub-centric development workflow. Skills follow the [Agent Skills](https://agentskills.io) open standard.
+Forge is a collection of agent skills that define a structured development workflow with pluggable issue tracking. Skills follow the [Agent Skills](https://agentskills.io) open standard.
 
 `AGENTS.md` is the canonical project guidance file in this repository. `CLAUDE.md` is kept only as a compatibility symlink for tools that still look for that filename.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,9 +4,15 @@ Forge's shared vocabulary. This file defines language used across multiple skill
 
 ## Language
 
-**Issue tracker** — currently GitHub Issues via `gh` CLI; Issue IDs are `#<number>`. Forge skills today assume GitHub; abstracting across providers (Linear, markdown folder) is on the roadmap, not yet reality.
+**Issue tracker** — the system that tracks Issues for a project. Forge supports three providers:
 
-**Issue** — one tracked unit of work in the Issue tracker. Carries title, body, priority, labels, and an AFK/HITL mode.
+- **GitHub** (default) — Issues via `gh` CLI. Issue IDs are `#<number>`. Used when AGENTS.md does not specify a provider, or specifies `github`.
+- **Markdown** — local `plan/` folder with `INDEX.md` and `issues/*.md` files. Issue IDs are the numeric prefix of the filename (e.g., `001-feature.md` → `#1`). Used when AGENTS.md specifies `markdown` or a `plan/` folder exists. See [plan-folder-spec.md](skills/forge-create-issue/references/plan-folder-spec.md) for the format.
+- **Other** (Linear, GitLab, etc.) — user-configured provider. AGENTS.md must declare the provider name and the tool or CLI used to interact with it. Skills use the declared tool where they would otherwise use `gh`.
+
+**Provider detection**: read the project's AGENTS.md for an issue tracker declaration. If none is found and a `plan/` directory exists at the repo root, use the markdown provider. Otherwise default to GitHub.
+
+**Issue** — one tracked unit of work in the Issue tracker. Carries title, body, priority, labels, and an AFK/HITL mode. The format varies by provider but the concept is the same across all three.
 
 **Plan** — a structured proposal for implementing an Issue: durable decisions, vertical phases, verification steps. Lives either inline in conversation or as a markdown file referenced by skills.
 
@@ -18,7 +24,7 @@ Forge's shared vocabulary. This file defines language used across multiple skill
 
 **Finding** — one issue surfaced by reflection or peer review, severity-tagged P0–P3. P3 findings are not flagged.
 
-**Deferred item** — a Finding not addressed in the current PR; becomes a new Issue.
+**Deferred item** — a Finding not addressed in the current PR; becomes a new Issue in the project's Issue tracker.
 
 **Composite skill** — a skill that orchestrates other skills rather than doing work itself. Currently only `forge-ship` (composes `forge-implement` + `forge-reflect`).
 
@@ -49,6 +55,6 @@ Forge's shared vocabulary. This file defines language used across multiple skill
 
 ## Flagged ambiguities
 
-- "issue" was previously used to mean GitHub Issues specifically — resolved: **Issue** (capitalized) is the abstract concept, even though only the GitHub provider is implemented today.
+- "issue" was previously used to mean GitHub Issues specifically — resolved: **Issue** (capitalized) is the abstract concept; the provider (GitHub, markdown, or other) is determined per-project.
 - "plan" was used loosely for both the structured proposal and a markdown file containing one — resolved: **Plan** is the proposal; "plan file" is a markdown artifact that contains a Plan.
 - "review" was used for both reflection (self-review) and peer review (external GitHub PR review) — resolved: **Reflection** is self-review by parallel sub-agents; **peer review** is external.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <strong>Agent skills for structured, GitHub-centric development.</strong><br>
+  <strong>Agent skills for structured development with pluggable issue tracking.</strong><br>
   One workflow. Six skills. From idea to review-ready code.
 </p>
 
@@ -26,8 +26,8 @@ Forge skills follow the [Agent Skills](https://agentskills.io) open standard and
 |-------|---------|---------|
 | Setup Project | `/forge-setup-project` | Set up or audit a project's context infrastructure for agentic engineering |
 | Shape | `/forge-shape` | Shape a vague idea into a clear plan through one-at-a-time structured questioning |
-| Create Issue | `/forge-create-issue` | Collaboratively plan and create GitHub issues |
-| Implement | `/forge-implement <input>` | Implement from a GitHub issue, plan file, or description |
+| Create Issue | `/forge-create-issue` | Collaboratively plan and create Issues (GitHub, markdown, or other provider) |
+| Implement | `/forge-implement <input>` | Implement from an Issue, plan file, or description |
 | Reflect | `/forge-reflect` | Self-review changes (PR, branch, or uncommitted) |
 | Address PR Feedback | `/forge-address-pr-feedback` | Address unresolved PR review comments |
 | **Ship** | **`/forge-ship <input>`** | **Implement + review in one invocation** |

--- a/RESHAPE.md
+++ b/RESHAPE.md
@@ -32,21 +32,21 @@ Pocock's workshop validated nearly every existing forge primitive (vertical slic
 | [#36](https://github.com/mgratzer/forge/pull/36) | Push vs pull context loading | Design Decisions row in `architecture.md`; `forge-reflect` and `forge-ship` refactored to push review context into sub-agent initial prompts; `forge-reviewer` role updated to expect pushed context |
 | [#37](https://github.com/mgratzer/forge/pull/37) | Deep-modules companion | Companion: `deep-modules.md` covering Ousterhout's deep-vs-shallow philosophy, testability argument, "delegate implementation, design interfaces" insight, module-shape audit checklist; referenced from forge-implement Step 2 and forge-reflect's Code Reuse & Quality dimension |
 | [#38](https://github.com/mgratzer/forge/pull/38) | Verify-before-assume companion | Companion: `verify-before-assume.md` covering API hallucination (version drift, interpolation, flag invention), the verification discipline, and when verification isn't needed; referenced from forge-implement Step 4 |
+| [#39](https://github.com/mgratzer/forge/pull/39) | Barrel-imports companion | Companion: `barrel-imports.md` covering why agents default to barrel files, the real costs, when barrels earn their cost, and the discipline; referenced from forge-implement Step 4 |
 
 ## In progress
 
-- **This PR**: Barrel-imports companion — `barrel-imports.md` under `forge-implement/references/` covering why agents default to barrel files, the real costs (circular deps, tree-shaking, obscured origin, merge conflicts), when barrels earn their cost (published API boundary, existing convention, framework requirement), and the discipline (check before creating). Referenced from forge-implement Step 4 ("as you code" — existing patterns bullet) and forge-reflect's Code Reuse & Quality dimension (new item 5). Resolves open decision on barrel-imports placement.
+- **This PR**: Issue tracker abstraction — CONTEXT.md gains the three-provider model (GitHub default, markdown `plan/` folder, user-configured other) with detection logic. New companion `plan-folder-spec.md` defines the markdown format. All six issue-touching skills refactored with provider-conditional blocks. Resolves open decision on abstraction shape (refactor existing, not new skill). Design Decisions row added to architecture.md.
 
 ## Next
 
 Ordered by leverage. Each is its own PR.
 
-1. **Issue tracker abstraction (Linear, markdown `plan/` folder)** — currently noted as roadmap in `CONTEXT.md`. Promote to implementation: user repos declare provider in their `AGENTS.md` or `CONTEXT.md`; forge skills speak abstractly ("the Issue tracker") and the LLM dispatches to the actual tool. Markdown variant gets first-class spec (`plan/INDEX.md` + `plan/issues/*.md` with frontmatter).
-2. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
+1. **forge-shape grill-style further refinement** (optional) — if Step 2 in practice does not surface clear approaches, revisit whether Step 3's conditional approach-exploration earns its place or should always run.
 
 ## Open decisions
 
-- **Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill? Lean: refactor existing — adding a parallel skill creates the same "which one do I use" problem we avoided with shape.
+- ~~**Issue tracker abstraction shape**: refactor `forge-create-issue` or new skill?~~ **Resolved**: refactored existing skills — all six issue-touching skills gained provider-conditional blocks. No new skills created.
 - **What other scattered craft frustrations** belong as companions? User mentioned deep modules, barrel imports, and API hallucination. All three are now addressed as companions. Capture more as they surface, default to companion-under-existing-skill before considering a new skill.
 
 ## Anti-goals

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Forge is a prompt-only repository — no application code, no runtime, no dependencies. It contains Agent Skills prompt files (`SKILL.md`) that teach compatible agents how to execute a structured GitHub development workflow.
+Forge is a prompt-only repository — no application code, no runtime, no dependencies. It contains Agent Skills prompt files (`SKILL.md`) that teach compatible agents how to execute a structured development workflow with pluggable issue tracking (GitHub, markdown `plan/` folder, or user-configured provider).
 
 ## Project Structure
 
@@ -13,7 +13,9 @@ forge/
 │   ├── forge-shape/                        # Optional: Shape ideas into plans before issue creation
 │   │   ├── SKILL.md
 │   │   └── references/shaping-methodology.md  # One-at-a-time questioning philosophy
-│   ├── forge-create-issue/SKILL.md        # Step 1: Plan and create GitHub issues
+│   ├── forge-create-issue/
+│   │   ├── SKILL.md                       # Step 1: Plan and create Issues (provider-agnostic)
+│   │   └── references/                    # Slicing philosophy, AFK/HITL, plan-folder spec
 │   ├── forge-implement/
 │   │   ├── SKILL.md                       # Step 2: Implement from issue, plan, or description
 │   │   ├── references/                    # Progressive disclosure: implementation craft companions
@@ -45,7 +47,7 @@ forge-setup-project → [forge-shape →] forge-create-issue → forge-implement
 
 - **forge-setup-project** sets up or audits a project's context infrastructure using a three-tier model: `AGENTS.md` as lean hot memory, `docs/` as earned warm memory, and `specs/` (or equivalent) as cold memory, with signal-to-noise scoring for existing guidance. It also supports migrating legacy `CLAUDE.md`-first repos to an `AGENTS.md`-first layout.
 - **forge-shape** investigates the codebase, shapes the problem through one-at-a-time questioning until a shared design concept emerges, optionally explores contrasting approaches if shaping didn't surface one, and produces a plan summary ready for issue creation
-- **forge-create-issue** uses AskUserQuestion to collaboratively scope work, then creates GitHub issues with `gh`
+- **forge-create-issue** uses AskUserQuestion to collaboratively scope work, then creates Issues in the project's Issue tracker (GitHub, markdown `plan/` folder, or user-configured provider)
 - **forge-implement** reads an issue, plan file, or free-text description, researches the codebase (optionally via blind scout delegation for complex work), plans vertical implementation phases, and opens a PR
 - **forge-reflect** self-reviews changes (PR, branch diff, or uncommitted) via four parallel reviewer agents (correctness, security, code quality, efficiency) using a P0-P3 severity rubric
 - **forge-address-pr-feedback** fetches unresolved review threads via GraphQL and addresses each one
@@ -160,5 +162,6 @@ The instruction-budget figure (~150–200 instructions) is a related but distinc
 | Three-tier context model | Hot (`AGENTS.md`) / Warm (`docs/`) / Cold (specs) | Generic context hurts agent performance — tiered model ensures each doc earns its token cost |
 | Compatibility layer | `CLAUDE.md` symlink to `AGENTS.md` | Preserve compatibility without making vendor-specific filenames canonical |
 | Push vs pull context loading | Push = embed content in initial prompt; Pull = read on demand via file references | Push when reliability matters more than token economy (review rubric, role definitions); pull for optional philosophy and templates that the agent may not need. Progressive disclosure (`references/`) is pull by default; delegation prompts should push critical instructions so sub-agents don't skip or misread them |
+| Issue tracker abstraction | Provider-conditional blocks in skills, not a code interface | Skills are prompts — the LLM reads the provider from AGENTS.md and dispatches to the right tool; no adapter pattern needed |
 | Undiscoverability test | Only document what agents can't find by exploring | Agents that build own context outperform pre-loaded context; docs should contain decisions, conventions, failure modes |
 | Agent readiness assessment | Evaluate feedback loops, module structure, and risks during setup | Architecture and feedback loops affect agent output more than context files — surface gaps early |

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -72,7 +72,7 @@ Role files live inside the skill directory to ensure portable installation. If m
 
 ## Bash Examples in Skills
 
-- Every `gh` command must be a valid GitHub CLI command
+- Every `gh` command must be a valid GitHub CLI command (used in GitHub provider paths)
 - Use placeholder syntax consistently: `<ISSUE_NUMBER>`, `<OWNER>`, `<REPO>`, `<BRANCH_NAME>`
 - Include comments in multi-step bash blocks explaining each command
 - Show both the command and the expected usage pattern
@@ -90,7 +90,7 @@ Conventions shared across skills. When modifying any, update every skill that re
 | Pre-flight validation | Verify external deps, config placement, generated types before feature code | implement |
 | Test as you go | Run tests after each commit, not just at the end | implement |
 | Pattern audit | When changing a pattern, update ALL files using it | implement, reflect |
-| Mandatory deferred tracking | Create GitHub issues for all deferred items found in reflection | reflect |
+| Mandatory deferred tracking | Create Issues (in the project's Issue tracker) for all deferred items found in reflection | reflect |
 | Trailing context syntax | Append `-- <additional context>` as the final invocation segment for skills with structured primary input | setup-project, shape, implement, reflect, address-pr-feedback |
 | Review severity | P0-P3 (see reflect/references/review-rubric.md) | reflect, ship |
 | Sub-agent delegation | `context: fork` frontmatter + `(delegate)` step marker with role reference or self-contained instructions and inline fallback | shape, implement, reflect |
@@ -106,6 +106,7 @@ Conventions shared across skills. When modifying any, update every skill that re
 | Skill composition | Composite skills reference other skills by path; orchestrators stay lean | ship |
 | Tool-layer integration | Reference external tools (e.g., `subagent`) by name with inline fallback | ship |
 | Unattended mode | `--unattended` flag skips user interaction; plan approval auto-proceeds, triage uses severity (P0–P1 fix, P2–P3 defer) | ship, implement |
+| Issue tracker providers | Provider-conditional blocks for issue create/read/search/defer; GitHub default, markdown `plan/`, other via AGENTS.md | create-issue, implement, reflect, ship, shape, address-pr-feedback |
 | Workflow order | setup → [shape →] create → implement → reflect → address; ship composes implement + reflect | All skills |
 
 ## Instruction Budget

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Git
-- [GitHub CLI](https://cli.github.com/) (`gh`) — used by skills for all GitHub operations
+- [GitHub CLI](https://cli.github.com/) (`gh`) — used by skills for GitHub issue and PR operations (only required when GitHub is the issue tracker provider)
 - A compatible coding agent that supports Agent Skills slash commands
 
 No language runtime, package manager, or build tools are needed. The repository contains only Markdown files.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,8 @@ gh pr create --help
 
 For GraphQL queries in `forge-address-pr-feedback`, verify the query structure against the [GitHub GraphQL API docs](https://docs.github.com/en/graphql).
 
+**Markdown provider path:** when modifying skills that use the `plan/` folder provider, verify that file operations match [plan-folder-spec.md](../skills/forge-create-issue/references/plan-folder-spec.md) — correct directory structure, frontmatter fields, and INDEX.md updates.
+
 ### 3. End-to-End Manual Testing
 
 The most reliable test is running the skill on a real project:
@@ -57,4 +59,13 @@ grep -rn "additional context\|-- <additional context>" \
   skills/forge-implement \
   skills/forge-reflect \
   skills/forge-address-pr-feedback
+
+# Check provider-conditional blocks stay in sync across skills
+grep -rn "GitHub\|Markdown\|Other provider" \
+  skills/forge-create-issue/SKILL.md \
+  skills/forge-implement/SKILL.md \
+  skills/forge-reflect/SKILL.md \
+  skills/forge-ship/SKILL.md \
+  skills/forge-shape/SKILL.md \
+  skills/forge-address-pr-feedback/SKILL.md
 ```

--- a/skills/forge-address-pr-feedback/SKILL.md
+++ b/skills/forge-address-pr-feedback/SKILL.md
@@ -103,8 +103,9 @@ Reply format by category:
 
 ### Step 4: Create Follow-up Issues
 
-For valid out-of-scope improvements:
+For valid out-of-scope improvements, create an Issue in the project's Issue tracker:
 
+**GitHub:**
 ```bash
 gh issue create \
   --title "<description>" \
@@ -114,6 +115,10 @@ gh issue create \
 
 Proposed solution: <what should be done>"
 ```
+
+**Markdown:** create a new issue file per the [plan-folder-spec](../forge-create-issue/references/plan-folder-spec.md) with the PR context in the body, and commit it.
+
+**Other provider:** use the tool declared in AGENTS.md.
 
 ### Step 5: Push and Summarize
 

--- a/skills/forge-create-issue/SKILL.md
+++ b/skills/forge-create-issue/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: forge-create-issue
-description: Collaboratively plan and create well-structured GitHub issues through interactive discussion. Use when the user wants to create a GitHub issue, plan a feature, report a bug, or scope out work for implementation.
+description: Collaboratively plan and create well-structured Issues through interactive discussion. Use when the user wants to create an Issue, plan a feature, report a bug, or scope out work for implementation. Supports GitHub, markdown plan/ folder, and other providers.
 disable-model-invocation: true
 allowed-tools: Read, Bash, Grep, Glob, WebSearch
 ---
 
-# Create GitHub Issue
+# Create Issue
 
-Collaboratively plan and create well-structured GitHub issues through interactive discussion.
+Collaboratively plan and create well-structured Issues through interactive discussion. The Issue is created in the project's Issue tracker — see [CONTEXT.md](../../CONTEXT.md) for provider detection.
 
 ## Input
 
@@ -66,7 +66,7 @@ If splitting makes sense, offer: single Issue, multiple linked Issues, or epic w
 
 **Title:** Use conventional commit format — `<type>(<scope>): <description>`
 
-**Labels:** Discover available labels with `gh label list`. Apply at least one type label and relevant area labels.
+**Labels:** When using GitHub, discover available labels with `gh label list`. When using the markdown provider, choose labels freely — there is no predefined set. Apply at least one type label and relevant area labels.
 
 **Body structure:**
 
@@ -94,8 +94,9 @@ If splitting makes sense, offer: single Issue, multiple linked Issues, or epic w
 
 ### Step 6: Review and Create
 
-Present the draft to the user. Iterate until satisfied. Then create:
+Present the draft to the user. Iterate until satisfied. Then create the Issue in the project's Issue tracker:
 
+**GitHub:**
 ```bash
 gh issue create \
   --title "<type>(<scope>): <description>" \
@@ -105,10 +106,15 @@ EOF
 )" \
   --label "<labels>"
 ```
-
 For epics, create the parent issue first, then sub-issues with `--parent <PARENT_NUMBER>`.
 
-Share the issue URL. Suggest using `forge-implement` to start implementation.
+**Markdown** (`plan/` folder):
+Create the issue file following the [plan-folder-spec](references/plan-folder-spec.md) — determine the next ID, write `plan/issues/<ID>-<slug>.md` with frontmatter and body, and append a row to `plan/INDEX.md`. Commit the new files.
+
+**Other provider:**
+Use the tool or CLI declared in the project's AGENTS.md to create the issue with the same title, body, and labels.
+
+Share the issue reference. Suggest using `forge-implement` to start implementation.
 
 ## Guidelines
 

--- a/skills/forge-create-issue/SKILL.md
+++ b/skills/forge-create-issue/SKILL.md
@@ -106,7 +106,7 @@ EOF
 )" \
   --label "<labels>"
 ```
-For epics, create the parent issue first, then sub-issues with `--parent <PARENT_NUMBER>`.
+For GitHub epics, create the parent issue first, then sub-issues with `--parent <PARENT_NUMBER>`.
 
 **Markdown** (`plan/` folder):
 Create the issue file following the [plan-folder-spec](references/plan-folder-spec.md) — determine the next ID, write `plan/issues/<ID>-<slug>.md` with frontmatter and body, and append a row to `plan/INDEX.md`. Commit the new files.

--- a/skills/forge-create-issue/references/plan-folder-spec.md
+++ b/skills/forge-create-issue/references/plan-folder-spec.md
@@ -1,0 +1,86 @@
+# Plan Folder Spec
+
+The markdown issue tracker provider for projects that track work locally instead of in a hosted service.
+
+## When to use it
+
+Use the `plan/` folder when the project has no hosted issue tracker, when the team prefers issues-as-code versioned alongside the codebase, or when working offline. The folder lives at the repository root.
+
+## Directory structure
+
+```text
+plan/
+├── INDEX.md
+└── issues/
+    ├── 001-setup-auth.md
+    ├── 002-fix-login-redirect.md
+    └── ...
+```
+
+**INDEX.md** is the entry point — a table that lists every issue with its current status. Skills read it to discover issues and write to it when creating or closing them.
+
+**issues/*.md** files are individual issues. The filename is `<ID>-<slug>.md` where `<ID>` is a zero-padded numeric identifier and `<slug>` is a kebab-case summary.
+
+## Issue file format
+
+```yaml
+---
+id: 1
+title: "feat(auth): add OAuth support"
+status: open
+labels: [enhancement]
+mode: AFK
+created: 2026-04-30
+---
+```
+
+| Field | Required | Values |
+|-------|----------|--------|
+| `id` | Yes | Positive integer, unique across the project |
+| `title` | Yes | Conventional commit format |
+| `status` | Yes | `open`, `in-progress`, `closed` |
+| `labels` | No | List of label strings |
+| `mode` | No | `AFK` or `HITL` (defaults to `HITL`) |
+| `created` | Yes | ISO date |
+
+The body below the frontmatter uses the same structure as any forge issue: Summary, Problem / Motivation, Proposed Solution, Acceptance Criteria.
+
+## INDEX.md format
+
+```markdown
+# Plan
+
+| ID | Title | Status | Labels | Mode |
+|----|-------|--------|--------|------|
+| 1 | feat(auth): add OAuth support | open | enhancement | AFK |
+| 2 | fix(login): redirect loop on expired session | open | bug | HITL |
+```
+
+The table is the source of truth for status. When a skill closes an issue, it updates both the issue file's `status` frontmatter and the INDEX.md row.
+
+## Creating an issue
+
+1. Determine the next ID: read INDEX.md, find the highest existing ID, increment by one.
+2. Create `plan/issues/<ID>-<slug>.md` with frontmatter and body.
+3. Append a row to the INDEX.md table.
+
+If the `plan/` directory or `plan/issues/` subdirectory doesn't exist, create them.
+
+## Reading an issue
+
+Read `plan/issues/<ID>-*.md` (glob on the ID prefix). Parse YAML frontmatter for metadata, body for requirements and acceptance criteria.
+
+## Searching issues
+
+Grep INDEX.md for keywords, or scan `plan/issues/` filenames and frontmatter.
+
+## Closing an issue
+
+1. Update the issue file's `status` frontmatter to `closed`.
+2. Update the corresponding INDEX.md row's Status column to `closed`.
+
+## Common mistakes
+
+- **Letting INDEX.md drift from issue files.** Always update both when changing status. INDEX.md is what skills scan first; stale rows cause missed or duplicate work.
+- **Skipping the ID in filenames.** Skills rely on the `<ID>-` prefix to locate issue files by number. Descriptive-only filenames break `plan/issues/<ID>-*.md` lookups.
+- **Using non-numeric IDs.** Forge skills reference issues as `#<number>` in commit messages and cross-references. String IDs break this convention.

--- a/skills/forge-implement-issue/SKILL.md
+++ b/skills/forge-implement-issue/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # ⚠️ Renamed to `forge-implement`
 
-This skill was renamed to **`forge-implement`** — it now accepts GitHub issues, plan files, and free-text descriptions.
+This skill was renamed to **`forge-implement`** — it now accepts Issues, plan files, and free-text descriptions.
 
 **Tell the user:**
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge-implement
-description: Implement a feature or fix from a GitHub issue, plan file, or free-text description, following project standards. Use when the user wants to start working on a GitHub issue, implement a feature, fix a bug, or build from a plan or roadmap.
+description: Implement a feature or fix from an Issue, plan file, or free-text description, following project standards. Use when the user wants to start working on an Issue, implement a feature, fix a bug, or build from a plan or roadmap.
 disable-model-invocation: true
 ---
 
@@ -10,13 +10,13 @@ Implement a feature or fix following project standards.
 
 ## Input
 
-Primary input: a GitHub issue, a plan file, or a free-text description.
+Primary input: an Issue (from the project's Issue tracker), a plan file, or a free-text description.
 
 Optional last parameter: `-- <additional context>`
 
 Interpret `$ARGUMENTS` as one of:
-- `<issue-number>` — GitHub issue
-- `<issue-url>` — GitHub issue URL
+- `<issue-number>` — Issue in the project's Issue tracker
+- `<issue-url>` — Issue URL (GitHub, Linear, etc.)
 - `<file-path>` — path to a plan, roadmap, or spec file
 - `<free-text>` — inline description of what to build
 - Any of the above followed by `-- <additional context>`
@@ -27,13 +27,15 @@ Use any additional context as execution guidance while still following the requi
 
 ### Step 1: Understand the Work
 
-Determine the input type and extract requirements:
+Determine the input type and extract requirements. Detect the project's Issue tracker provider (see [CONTEXT.md](../../CONTEXT.md)).
 
-**GitHub issue** (number or URL):
-```bash
-gh issue view <ISSUE_NUMBER> --json number,title,body,labels,assignees,milestone,state,comments
-```
-Parse: title, requirements, acceptance criteria, labels, sub-issues, comments, and linked work. If labels are missing, add appropriate ones with `gh issue edit`.
+**Issue** (number or URL) — fetch from the project's Issue tracker:
+
+- **GitHub**: `gh issue view <ISSUE_NUMBER> --json number,title,body,labels,assignees,milestone,state,comments`
+- **Markdown**: Read `plan/issues/<ISSUE_NUMBER>-*.md` — parse YAML frontmatter and body
+- **Other provider**: use the tool declared in AGENTS.md
+
+Parse: title, requirements, acceptance criteria, labels, sub-issues, comments, and linked work. If labels are missing and the provider supports editing, add appropriate ones.
 
 **Plan file** (path to a roadmap, spec, or plan):
 Read the file. Extract: goals, requirements, constraints, and acceptance criteria.
@@ -163,7 +165,7 @@ Report: branch name, PR link, commits made, files changed, tests added, docs upd
 
 ## Sub-Issue Handling
 
-When working from a GitHub issue with sub-issues, treat each as a separate task. Close sub-issues as you complete them — GitHub automatically updates parent progress.
+When working from an Issue with sub-issues, treat each as a separate task. Close sub-issues as you complete them. For GitHub, parent progress updates automatically; for markdown, update both the issue file status and the INDEX.md row.
 
 ## Related Skills
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -27,7 +27,7 @@ Use any additional context as execution guidance while still following the requi
 
 ### Step 1: Understand the Work
 
-Determine the input type and extract requirements. Detect the project's Issue tracker provider (see [CONTEXT.md](../../CONTEXT.md)).
+Determine the input type and extract requirements. Detect the project's Issue tracker provider: check AGENTS.md for a declaration, fall back to `plan/` directory if present, otherwise default to GitHub (see [CONTEXT.md](../../CONTEXT.md) for details).
 
 **Issue** (number or URL) — fetch from the project's Issue tracker:
 

--- a/skills/forge-reflect/SKILL.md
+++ b/skills/forge-reflect/SKILL.md
@@ -99,10 +99,10 @@ For each item, recommend one of:
 
 State your recommendation and let the user decide. Then:
 - **Fix now items:** apply the fix and commit it
-- **Deferred items:** create a GitHub issue to track:
-  ```bash
-  gh issue create --title "<title>" --body "<context and proposed solution>"
-  ```
+- **Deferred items:** create an Issue in the project's Issue tracker:
+  - **GitHub**: `gh issue create --title "<title>" --body "<context and proposed solution>"`
+  - **Markdown**: create a new issue file per the [plan-folder-spec](../forge-create-issue/references/plan-folder-spec.md) and commit it
+  - **Other provider**: use the tool declared in AGENTS.md
 
 ## Output Format
 
@@ -138,7 +138,7 @@ State your recommendation and let the user decide. Then:
 
 - **Pattern consistency is the highest-value check** — a missed pattern update causes bugs across the codebase
 - **Skip noise** — see [review rubric](references/review-rubric.md) for severity calibration and what not to flag
-- **Triage deferred items with the user** — ask whether each item should be fixed now or deferred as a follow-up issue; only create issues for confirmed deferrals
+- **Triage deferred items with the user** — ask whether each item should be fixed now or deferred as a follow-up Issue; only create Issues for confirmed deferrals
 - **Run quality gates before reporting** — catch issues before the reviewer does
 - **Prefer fresh context** — a reviewer without implementation memory catches issues the author overlooks
 - **Aggregate and deduplicate** — findings from the four agents may overlap; merge duplicates and keep the highest severity

--- a/skills/forge-shape/SKILL.md
+++ b/skills/forge-shape/SKILL.md
@@ -26,10 +26,10 @@ Before asking any questions, explore the codebase for related context:
 - Identify integration points, dependencies, and architectural boundaries
 - Look for prior attempts or related work (git log, closed issues)
 
-```bash
-# Check for related issues
-gh issue list --state all --search "<relevant keywords>"
-```
+Check for related Issues in the project's Issue tracker:
+- **GitHub**: `gh issue list --state all --search "<relevant keywords>"`
+- **Markdown**: grep `plan/INDEX.md` and `plan/issues/` for relevant keywords
+- **Other provider**: use the tool declared in AGENTS.md
 
 ### Step 2: Shape the Problem
 
@@ -112,7 +112,7 @@ The summary is *evidence* of alignment, not the alignment itself. If the user re
 
 ## Related Skills
 
-**Next step:** Use `forge-create-issue` to turn the plan into GitHub issues.
+**Next step:** Use `forge-create-issue` to turn the plan into Issues.
 
 ## Example Usage
 

--- a/skills/forge-ship/SKILL.md
+++ b/skills/forge-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: forge-ship
-description: End-to-end implementation and self-review in a single invocation. Implements from a GitHub issue, plan file, or free-text description, then delegates review to fresh-context reviewer sub-agents. Use when the user wants to implement and review without manual handoff between skills.
+description: End-to-end implementation and self-review in a single invocation. Implements from an Issue, plan file, or free-text description, then delegates review to fresh-context reviewer sub-agents. Use when the user wants to implement and review without manual handoff between skills.
 disable-model-invocation: true
 ---
 
@@ -10,13 +10,13 @@ Implement end to end — code it, review it, ship it. Implementation runs in the
 
 ## Input
 
-Primary input: a GitHub issue, a plan file, or a free-text description.
+Primary input: an Issue (from the project's Issue tracker), a plan file, or a free-text description.
 
 Optional last parameter: `-- <additional context>`
 
 Interpret `$ARGUMENTS` the same way as `forge-implement`:
-- `<issue-number>` — GitHub issue
-- `<issue-url>` — GitHub issue URL
+- `<issue-number>` — Issue in the project's Issue tracker
+- `<issue-url>` — Issue URL (GitHub, Linear, etc.)
 - `<file-path>` — path to a plan, roadmap, or spec file
 - `<free-text>` — inline description of what to build
 - Any of the above followed by `-- <additional context>`
@@ -85,17 +85,17 @@ Aggregate and deduplicate findings from all four review agents.
 **In attended mode (default):** present each finding to the user with a recommendation:
 
 - **Fix now** — small, low-effort changes that fit in this PR → apply fix, commit
-- **Defer** — larger changes that expand PR scope → create a GitHub issue
+- **Defer** — larger changes that expand PR scope → create an Issue in the project's Issue tracker
 
 **In unattended mode:** auto-triage using severity from the [review rubric](../forge-reflect/references/review-rubric.md):
 
 - **P0–P1** → fix now, commit
-- **P2–P3** → defer, create a GitHub issue
+- **P2–P3** → defer, create an Issue in the project's Issue tracker
 
-For both modes, deferred items become GitHub issues:
-```bash
-gh issue create --title "<title>" --body "<context and proposed solution>"
-```
+For both modes, deferred items become Issues:
+- **GitHub**: `gh issue create --title "<title>" --body "<context and proposed solution>"`
+- **Markdown**: create a new issue file per the [plan-folder-spec](../forge-create-issue/references/plan-folder-spec.md) and commit it
+- **Other provider**: use the tool declared in AGENTS.md
 
 ### Step 5: Summary
 


### PR DESCRIPTION
## Summary

- Makes all issue-touching forge skills provider-agnostic — supports GitHub (default), markdown `plan/` folder, and user-configured providers (Linear, GitLab, etc.)
- Defines the provider model in CONTEXT.md with detection logic: check AGENTS.md declaration → check for `plan/` directory → default to GitHub
- New companion `plan-folder-spec.md` under forge-create-issue defines the `plan/INDEX.md` + `plan/issues/*.md` format for the markdown provider
- All six issue-touching skills (create-issue, implement, reflect, ship, shape, address-pr-feedback) gain provider-conditional blocks at their issue create/read/search/defer touchpoints
- Design Decisions row in architecture.md explains the natural-language dispatch pattern (LLM reads provider from AGENTS.md, no adapter pattern needed)

## Changes

| File | Change |
|------|--------|
| `CONTEXT.md` | Three-provider model, detection logic, updated Issue/Deferred item definitions |
| `forge-create-issue/references/plan-folder-spec.md` | **New** — markdown provider format spec (86 lines) |
| `forge-create-issue/SKILL.md` | Title → "Create Issue", provider-conditional label discovery and creation |
| `forge-implement/SKILL.md` | Provider-conditional issue reading in Step 1, multi-provider sub-issue handling |
| `forge-reflect/SKILL.md` | Provider-conditional deferred item creation |
| `forge-ship/SKILL.md` | Provider-conditional deferred item creation in triage step |
| `forge-shape/SKILL.md` | Provider-conditional issue search |
| `forge-address-pr-feedback/SKILL.md` | Provider-conditional follow-up issue creation |
| `docs/architecture.md` | Description, project structure, and new Design Decisions row |
| `docs/development.md` | `gh` prerequisite scoped to GitHub provider |
| `docs/coding-guidelines.md` | New cross-skill consistency row, updated deferred tracking |
| `RESHAPE.md` | Barrel-imports → Done, issue tracker → In Progress, open decision resolved |
| `forge-implement-issue/SKILL.md` | Legacy stub updated to provider-agnostic language |

## Design notes

The abstraction is **linguistic, not architectural**. Since forge skills are prompts, provider-agnosticism works via conditional blocks in the prompt text. The LLM reads the project's AGENTS.md, detects the provider, and follows the matching branch. No interface, no adapter, no factory — just natural language dispatch.

The `forge-address-pr-feedback` skill remains GitHub PR-specific for its PR interactions (GraphQL review threads) — only the follow-up issue creation step is provider-agnostic.

## Test plan

- [ ] Read each modified SKILL.md end-to-end — instructions coherent, no broken references
- [ ] Verify `plan-folder-spec.md` covers full issue lifecycle (create, read, search, close)
- [ ] Cross-reference CONTEXT.md provider definitions against skill conditional blocks
- [ ] Verify coding-guidelines.md cross-skill consistency table covers the new convention
- [ ] Confirm no remaining "GitHub issue" references in skills that should be provider-agnostic
- [ ] Check RESHAPE.md state: barrel-imports Done, issue tracker In Progress, open decision resolved