### PR TITLE
fix(skills): lead PR summaries with motivation from linked issue

### DIFF
--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -53,7 +53,7 @@ See [testing.md — Structural Review](testing.md#1-structural-review) for the c
 ```markdown
 ## Summary
 
-<1-2 sentences: what changed and why>
+<1-2 sentences: why this change was needed, then the approach taken>
 
 Closes #<issue-number>
 

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -102,7 +102,7 @@ Fix issues and commit fixes.
 git push -u origin <branch-name>
 ```
 
-Create PR with conventional commit title format. Include: summary of what was built (closing the issue when one exists), list of changes, test plan checklist, and quality checklist.
+Create PR with conventional commit title format. Lead the summary with **why** the change was needed — pull the motivation from the linked issue's problem statement; if no issue is linked, derive it from the branch's commit history. Then briefly describe the approach taken. Include: list of changes, test plan checklist, and quality checklist. Close the issue when one exists.
 
 If the implementation requires manual deployment steps (env vars, infra changes, container/runtime config, migrations), add a prominent `> [!WARNING]` block at the top of the PR body.
 

--- a/skills/forge-ship/SKILL.md
+++ b/skills/forge-ship/SKILL.md
@@ -61,7 +61,7 @@ Update `docs/*.md` and `AGENTS.md` if behavior or conventions changed.
 
 #### 1g. Push and create PR
 
-Push branch, create PR with conventional commit title. Include: summary (closing the issue), changes list, test plan, quality checklist. Add a `> [!WARNING]` block for manual deployment steps.
+Push branch, create PR with conventional commit title. Lead the summary with **why** the change was needed — pull the motivation from the linked issue's problem statement; if no issue is linked, derive it from the branch's commit history. Then briefly describe the approach taken. Include: changes list, test plan, quality checklist. Close the issue when one exists. Add a `> [!WARNING]` block for manual deployment steps.
 
 Do not produce the implementation summary yet — the review will inform the final report.
 


### PR DESCRIPTION
## Summary

PR descriptions generated by forge-ship and forge-implement were focusing on *what* was built rather than *why* the change was needed. The motivation exists upstream in the issue body but the PR creation instructions didn't tell the agent to carry it forward.

Reworded the PR creation step in both skills to explicitly pull motivation from the linked issue's problem statement, with a fallback to commit history for issueless workflows. Also aligned the pr-workflow.md template hint.

## Changes

- `skills/forge-ship/SKILL.md`: reworded step 1g to lead with "why" from the issue
- `skills/forge-implement/SKILL.md`: reworded step 8 to lead with "why" from the issue
- `docs/pr-workflow.md`: reordered template hint from "what and why" to "why, then approach"

## Test Plan

- [ ] Invoke `/forge-ship` on a test project with an issue — verify PR summary leads with motivation
- [ ] Invoke `/forge-implement` without an issue — verify fallback to commit history
- [ ] Check cross-skill consistency between forge-ship and forge-implement instructions