### PR TITLE
chore(skills): remove dated prompt patterns from skill suite

### DIFF
--- a/skills/_shared/phase-execution.md
+++ b/skills/_shared/phase-execution.md
@@ -50,5 +50,3 @@ Verify before proceeding to the next phase:
 - [ ] All tests pass (not just new ones)
 - [ ] No lint/type errors introduced
 - [ ] Commit the phase — one logical change per commit, conventional format
-
-Use TodoWrite to track progress through phases.

--- a/skills/_shared/review-delegation.md
+++ b/skills/_shared/review-delegation.md
@@ -30,7 +30,7 @@ Use the smallest review shape that still gives trustworthy signal:
 
 When using inline review, keep it to a single pass — do not escalate to sub-agents unless the diff is no longer tiny or new risk appears.
 
-When adding a second reviewer, assign it only the **highest-risk deep pass** from [review-dimensions](review-dimensions.md) — do not split the same diff into many overlapping reviewers.
+When adding a second reviewer, assign it only the **highest-risk deep pass** from [review-dimensions](review-dimensions.md).
 
 ## Compose Review Tasks
 

--- a/skills/forge-address-pr-feedback/SKILL.md
+++ b/skills/forge-address-pr-feedback/SKILL.md
@@ -20,10 +20,11 @@ PR number or URL (`$ARGUMENTS`; auto-detects from current branch if omitted). Op
 **Use GraphQL** — the REST API does NOT expose `isResolved` status on review threads.
 
 ```bash
-# Derive owner/repo from the checkout and the PR from the branch (or the number/URL given in $ARGUMENTS)
+# Derive owner/repo from the checkout; PR_ARG is the number or URL from $ARGUMENTS, empty when omitted
+PR_ARG=""
 OWNER=$(gh repo view --json owner --jq .owner.login)
 REPO=$(gh repo view --json name --jq .name)
-PR_NUMBER=$(gh pr view <PR_NUMBER_OR_URL_IF_GIVEN> --json number --jq .number)
+PR_NUMBER=$(gh pr view $PR_ARG --json number --jq .number)   # empty PR_ARG → PR for the current branch
 
 gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" -f query='
 query($owner: String!, $repo: String!, $pr: Int!) {

--- a/skills/forge-address-pr-feedback/SKILL.md
+++ b/skills/forge-address-pr-feedback/SKILL.md
@@ -20,10 +20,15 @@ PR number or URL (`$ARGUMENTS`; auto-detects from current branch if omitted). Op
 **Use GraphQL** — the REST API does NOT expose `isResolved` status on review threads.
 
 ```bash
-gh api graphql -f query='
-query {
-  repository(owner: "<OWNER>", name: "<REPO>") {
-    pullRequest(number: <PR_NUMBER>) {
+# Derive owner/repo from the checkout and the PR from the branch (or the number/URL given in $ARGUMENTS)
+OWNER=$(gh repo view --json owner --jq .owner.login)
+REPO=$(gh repo view --json name --jq .name)
+PR_NUMBER=$(gh pr view <PR_NUMBER_OR_URL_IF_GIVEN> --json number --jq .number)
+
+gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
       reviewThreads(first: 100) {
         nodes {
           isResolved
@@ -32,21 +37,14 @@ query {
           line
           id
           comments(first: 10) {
-            nodes {
-              id
-              body
-              author { login }
-              url
-            }
+            nodes { id body author { login } url }
           }
         }
       }
     }
   }
-}'
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
 ```
-
-Filter for unresolved threads: `select(.isResolved == false)`.
 
 ### Step 2: Process Each Thread
 
@@ -62,7 +60,7 @@ For **Discussion** threads where the decision is genuinely the user's to make, a
 
 ### Step 3: Address and Reply Individually
 
-**Address each thread immediately, then reply before moving to the next.** Do not batch.
+Address each thread and reply before moving to the next, so every reply can cite the commit that resolved it.
 
 For each thread:
 

--- a/skills/forge-create-issue/SKILL.md
+++ b/skills/forge-create-issue/SKILL.md
@@ -39,7 +39,7 @@ Verify external dependencies are accessible if relevant — flag broken ones bef
 
 **Skip this step** if the input already contains a chosen approach with rationale — the decision was already made through deliberate analysis. Proceed directly to Step 4.
 
-Otherwise, **always present 2-4 different approaches.** Never jump to a single solution.
+Otherwise, present the structurally distinct approaches you found — usually two to four — rather than a single recommendation; the choice belongs to the user.
 
 For each approach:
 - One-line summary

--- a/skills/forge-implement/SKILL.md
+++ b/skills/forge-implement/SKILL.md
@@ -22,7 +22,7 @@ Determine the input type and extract requirements. Detect the Issue tracker prov
 
 - **Issue** — fetch using the project's Issue tracker (see [issue-operations](../_shared/issue-operations.md)). Parse title, requirements, acceptance criteria, labels, sub-issues, comments. Add labels if missing. When the Issue has sub-issues, treat each as a separate task and close them as you complete them.
 - **Plan file** — extract goals, requirements, constraints, acceptance criteria.
-- **Free-text** — parse scope and constraints. Ask clarifying questions if underspecified.
+- **Free-text** — parse scope and constraints.
 
 Ask for clarification when requirements are too vague or dependencies too incomplete to plan confidently; in unattended mode, proceed on explicitly stated assumptions instead.
 
@@ -110,7 +110,7 @@ Report: branch name, PR link, commits made, files changed, tests added, docs upd
 ## Guidelines
 
 - **Explore before coding** — research the codebase before committing to an approach
-- **Ask when unsure** — better to clarify than implement wrong
+- **Ask when unsure** — better to clarify than implement wrong; unattended runs state their assumptions and proceed
 - **Don't scope creep** — implement what was asked, nothing more
 
 ## Related Skills

--- a/skills/forge-reflect/SKILL.md
+++ b/skills/forge-reflect/SKILL.md
@@ -68,11 +68,9 @@ Run the project's lint, format, type check, and test commands (and coverage wher
 
 Present each Finding to the user via AskUserQuestion and ask whether to **fix now** or **defer**.
 
-Bias hard toward **fix now**. Recommend deferral only when the Finding is truly out of scope, materially expands the PR, or needs separate design/review.
-
-For each Finding, recommend one of:
+For each Finding, recommend one of (bias toward fix now):
 - **Fix now** — default for in-scope findings and small follow-up work (e.g., missing tests, stale docs, duplicated lines, modest refactors that fit the current change)
-- **Defer** — only for larger or truly out-of-scope changes (e.g., a cross-cutting refactor, a new feature, a separate migration strategy)
+- **Defer** — only when the Finding is truly out of scope, materially expands the PR, or needs separate design/review (e.g., a cross-cutting refactor, a new feature, a separate migration strategy)
 
 State your recommendation and let the user decide. Then:
 - **Fix now:** apply the fix and commit it

--- a/skills/forge-ship/SKILL.md
+++ b/skills/forge-ship/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Ship a Change
 
-Implement end to end — code it, review it, ship it. Implementation runs in the current session; review always delegates to fresh context — this session authored the diff, so even tiny diffs get an unbiased reviewer — and deepens only when risk justifies it.
+Implement end to end — code it, review it, ship it. Implementation runs in the current session; review always delegates to fresh context and deepens only when risk justifies it.
 
 ## Input
 


### PR DESCRIPTION
## Why

A prompt audit of the skill suite against the current Claude generation found no pressure language or thinking scaffolds, but several accreted instructions: one rule fanned into multiple wordings across a single skill, a prohibition against a retired design of the same skill, a harness tool name that no longer exists, and one fragile step left to improvisation. Current models read instructions literally, so duplicates and phantom prohibitions cost reconciliation effort and can anchor toward the named failure.

## Changes

- **forge-create-issue**: "always present 2-4 approaches, never a single solution" restated at normal volume with its reason (the user owns the choice)
- **forge-address-pr-feedback**: the GraphQL fetch now derives owner/repo/PR itself and filters unresolved threads via `--jq` in one complete command; the reply-per-thread rule carries its reason (each reply cites the fixing commit)
- **review-delegation**: dropped the clause prohibiting the old four-reviewer design, which the model never saw
- **forge-ship**: dropped the duplicate self-review explanation from the intro; Step 2 and the Guidelines recap keep it
- **forge-reflect**: merged the adjacent duplicate fix-now/defer guidance, keeping the fuller deferral criteria
- **forge-implement**: removed the "ask if underspecified" sentence that contradicted unattended mode; the recap bullet now carries the unattended exception
- **phase-execution**: removed the `TodoWrite` reference

Deliberately kept: forge-ship's "Don't skip the review" guideline.

## Test plan

- [x] Patch applied cleanly via `git apply --check` before applying
- [x] Docs, README, and CONTEXT.md grep clean for every removed phrase
- [x] New GraphQL command in forge-address-pr-feedback run against a real PR with review threads

